### PR TITLE
Add support for Q Business Apps integrated with IdC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 # Microsoft Teams gateway for Amazon Q Business
-
-| :zap:        If you have created a new Amazon Q Business application on or after April 30th, 2024, you will not be able to set up a Slack or Microsoft Teams gateway using the instructions provided below. This is because new Amazon Q Business applications require integration with IAM Identity Center. We are currently working on updating the CloudFormation (CFN) template and the necessary steps to accommodate the setup of these gateways for new applications created since April 30th, 2024 with an expected completion date by May 30th, 2024.   |
+| :zap: If you created a new Amazon Q Business application on or after April 30th, 2024, you can now set up a Microsoft Teams gateway using the updated instructions provided below. These new Amazon Q Business applications are integrated with IAM Identity Center. The CloudFormation (CFN) template and the necessary steps have been updated to accommodate the setup of the Teams gateway for new applications.
 |-----------------------------------------|
 
-*See AWS Blog post: [Deploy a Microsoft Teams gateway for Amazon Q, your business expert](https://aws.amazon.com/blogs/machine-learning/deploy-a-microsoft-teams-gateway-for-amazon-q-your-business-expert/)*
-
+**Note:** The instructions provided in this guide are specific to Okta, but they should also work for other OIDC 2.0 compliant Identity Providers (IdPs) with minor adjustments.
 
 
 Amazon Q is a new generative AI-powered application that helps users get work done. Amazon Q can become your tailored business expert and let you discover content, brainstorm ideas, or create summaries using your company’s data safely and securely. For more information see: [Introducing Amazon Q, a new generative AI-powered assistant (preview)](https://aws.amazon.com/blogs/aws/introducing-amazon-q-a-new-generative-ai-powered-assistant-preview)
 
-In this repo we share a project which lets you use Amazon Q business expert's generative AI to enable Microsoft Teams members  to access your organizations data and knowledge sources via conversational question-answering. If you use Slack, refer to [Deploy a Slack gateway for Amazon Q, your business expert](https://aws.amazon.com/blogs/machine-learning/deploy-a-slack-gateway-for-amazon-q-your-business-expert/).  
+In this repo we share a project which lets you use Amazon Q business expert's generative AI to enable Microsoft Teams members to access your organizations data and knowledge sources via conversational question-answering.
  
 You can connect to your organization data via data source connectors and integrate it with Teams Gateway for Amazon Q business expert to enable access to your Teams channel members. It allows your users to:
 - Converse with Amazon Q business expert using Teams Direct Message (DM) to ask questions and get answers based on company data, get help creating new content such as emails, and performing tasks. 
@@ -25,7 +23,6 @@ It's easy to deploy in your own AWS Account, and add to your own teams. We show 
 ### Features
 - In DMs it responds to all messages
 - Renders answers containing markdown - e.g. headings, lists, bold, italics, tables, etc.
----
 - In channels it responds only to @mentions, and always replies in thread.
 - Provides thumbs up / down buttons to track user sentiment and help improve performance over time.
 - Provides Source Attribution - see references to sources used by Amazon Q.
@@ -44,26 +41,101 @@ Follow the instructions below to deploy the project to your own AWS account and 
 
 ### Prerequisites
 
-You need to have an AWS account and an IAM Role/User with permissions to create and manage the necessary resources and components for this application. *(If you do not have an AWS account, please see [How do I create and activate a new Amazon Web Services account?](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/))*
+1. You need to have an AWS account and an IAM Role/User with permissions to create and manage the necessary resources and components for this application. *(If you do not have an AWS account, please see [How do I create and activate a new Amazon Web Services account?](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/))*
 
-You also need to have an existing, working Amazon Q business expert application. If you haven't set one up yet, see [Creating an Amazon Q application](https://docs.aws.amazon.com/amazonq/latest/business-use-dg/create-app.html)
+2. You need to have an Okta Workforce Identity Cloud account. If you haven't signed up yet, see [Signing up for Okta](https://www.okta.com/)
 
-Lastly, you need a [Microsoft account](https://account.microsoft.com/) and a [Microsoft Teams subscription](https://www.microsoft.com/en-us/microsoft-teams/compare-microsoft-teams-business-options-b) to create and publish the app using the steps below. If you don’t have these, see if your company can create sandboxes for you to experiment, or create a new account and trial subscription as needed to complete the directions below.
+3. You need to configure SAML and SCIM with Okta and IAM Identity Center. If you haven't configured, see [Configuring SAML and SCIM with Okta and IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/gs-okta.html)
 
-### 1. Deploy the stack
+4. You also need to have an existing, working Amazon Q business application integrated with IdC. If you haven't set one up yet, see [Creating an Amazon Q application](https://docs.aws.amazon.com/amazonq/latest/business-use-dg/create-app.html)
 
+5. You need to have users subscribed to your Amazon Q business application, and are able to access Amazon Q Web Experience. If you haven't set one up yet, see [Subscribing users to an Amazon Q application](https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/adding-users-groups.html)
+
+6. You have aws cli latest version installed on your Linux or MacOS system. If you haven't installed yet, see [Installing the AWS CLI version 2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+
+7. Lastly, you need a [Microsoft account](https://account.microsoft.com/) and a [Microsoft Teams subscription](https://www.microsoft.com/en-us/microsoft-teams/compare-microsoft-teams-business-options-b) to create and publish the app using the steps below. If you don’t have these, see if your company can create sandboxes for you to experiment, or create a new account and trial subscription as needed to complete the directions below. You will need a Office 365 business subscription for Teams admin privileges. This subscription will also provide a business Microsoft account which will be needed since some steps cannot use an account with a personal email address. 
+
+### 1. Setup
+
+#### 1.1 Create an OIDC app integration, for the gateway, in Okta.
+
+Create the client as a ['Web app'](https://help.okta.com/en-us/content/topics/apps/apps_app_integration_wizard_oidc.htm). You will want to enable the 'Refresh Token' grant type, 'Allow everyone in your organization to access', and 'Federation Broker Mode'. Use a placeholder URL, like ```https://example.com```, for the redirect URI, as you will update this later (in step 3).
+
+#### 1.2 Create Trusted token issuer in IAM Identity Center
+
+Create trusted token issuer to trust tokens from OIDC issuer URL using these instructions listed here - https://docs.aws.amazon.com/singlesignon/latest/userguide/using-apps-with-trusted-token-issuer.html.
+Or you can run the below script.
+
+For the script, you need to have the OIDC issuer URL and the AWS region in which you have your Q business application. To retrieve the OIDC issuer URL, go to Okta account console, click the left hamburger menu and open Security > API and copy the whole 'Issuer URI'.
+
+The script will output trusted token issuer ARN (TTI_ARN) which you will use in the next step.
+
+```
+ export AWS_DEFAULT_REGION=<>
+ OIDC_ISSUER_URL=<>
+ bin/create-trusted-token-issuer.sh $OIDC_ISSUER_URL
+```
+
+#### 1.3 Create Customer managed application in IAM Identity Center
+
+Create customer managed IdC application by running below script.
+
+For the script, you need to have the OIDC client ID, trusted token issuer ARN, and the region in which you have your Q business application. To retrieve the OIDC client ID, go to Okta account console, click the left hamburger menu and open Applications > Applications and click on the application you created in step 1.1. Copy the 'Client ID'. For TTI_ARN, you can use the output from the previous step.
+
+The script will output the gateway IdC application ARN (GATEWAY_IDC_ARN) which you will use in the next step.
+
+```
+ export AWS_DEFAULT_REGION=<>
+ OIDC_CLIENT_ID=<>
+ TTI_ARN=<>
+ bin/create-idc-application.sh $OIDC_CLIENT_ID $TTI_ARN
+```
+
+### 2. Register a new app in the Microsoft Azure portal
+
+1. Go to the Azure Portal: https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade and login with your Microsoft account.
+1. Choose **+ New registration**
+   1. For **Name**, provide the name for your app, e.g. AMAZON-Q-TEAMS-GATEWAY.
+   1. For **Who can use this application or access this API?**, choose **Accounts in this organizational directory only (AWS only - Single tenant)**
+   1. Choose **Register**
+   1. *Note down the **Application (client) ID** value, and the **Directory (tenant) ID** from the **Overview** page. You'll need them later when asked for **MicrosoftAppId** and **MicrosoftAppTenantId**.*
+1. In the **API permissions** page (on the left navigation menu)
+   1. Choose **Add a permission**
+   1. Choose **Microsoft Graph**
+   1. Choose **Application permissions**
+   1. Select **User.Read.All**
+   1. Select **ChannelMessage.Read.All**
+   1. Select **Team.ReadBasic.All**
+   1. Select **Files.Read.All**
+   1. Choose **Add permissions**. *This permission allows the app to read data in your organization's directory about the signed in user.*
+   1. Remove the original **User.Read - Delegated** permission (use the … menu on the right to choose **Remove permission**)
+   1. Choose **✓ Grant admin consent for Default Directory**
+1. In the **Certificates & secrets** page
+   1. Choose **+ New client secret**
+   1. For **Description**, provide a value such as *\<Appname\>-client-secret*
+   1. Choose a value for **Expires**. *NOTE: In production, you'll need to manually rotate your secret before it expires.*
+   1. Choose **Add**
+   1. *Note down the **Value** (not Secret ID) for your new secret. You'll need it later when asked for **MicrosoftAppPassword**.*
+1. (Optional) Choose **Owners** to add any additional owners for the application.
+
+### 3. Deploy the stack
 We've made this easy by providing pre-built AWS CloudFormation templates that deploy everything you need in your AWS account.
 
 If you are a developer, and you want to build, deploy and/or publish the solution from code, we've made that easy too! See [Developer README](./README_DEVELOPERS.md)
 
 1. Log into the [AWS console](https://console.aws.amazon.com/) if you are not already.
 2. Choose one of the **Launch Stack** buttons below for your desired AWS region to open the AWS CloudFormation console and create a new stack.
-4. Enter the following parameters:
+3. Enter the following parameters:
     1. `Stack Name`: Name your App, e.g. AMAZON-Q-TEAMS-GATEWAY.
     2. `AmazonQAppId`: Your existing Amazon Q business expert application ID (copy from Amazon Q console). 
     3. `AmazonQRegion`: Choose the region where you created your Amazon Q business expert application.
-    4. `AmazonQUserId`: (Optional) Amazon Q User ID email address (leave empty to use Teams users email as user Id)
-    5. `ContextDaysToLive`: Just leave this as the default (90 days)
+    4. `OIDCIdPName`: The name of the OIDC external identity provider ('Okta' and 'Cognito' are explicitly supported, leave empty to use default for others)
+    5. `OIDCClientId`: The client ID of OIDC client you created in step 1.1.
+    6. `OIDCIssuerURL`: The issuer URL of the OIDC client you created in step 1.1.
+    7. `GatewayIdCAppARN`: The application arn of IdC customer managed application you created in step 1.3.
+    8. `MicrosoftAppId`: The `MicrosoftAppId` you copied in step 2.
+    9. `ContextDaysToLive`: Just leave this as the default (90 days)
+
 
 Region | Easy Deploy Button | Template URL - use to upgrade existing stack to a new release
 --- | --- | ---
@@ -73,44 +145,17 @@ Oregon (us-west-2) | [![Launch Stack](https://cdn.rawgit.com/buildkite/cloudform
 
 When your CloudFormation stack status is CREATE_COMPLETE, choose the **Outputs** tab, and keep it open - you'll need it below.
 
+### 4. Update OIDC Client Redirect URL.
 
-### 2. Configure your Teams bot application
+Go the app client settings created in IdP (in step 1.1), and update the client signin redirect URL with exported value in Cloudformation stack for the output with suffix `OIDCCallbackEndpointExportedName`.
 
-#### 2.1 Register a new app in the Microsoft Azure portal
-
-1. Go to the Azure Portal: https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade and login with your Microsoft account.
-1. Choose **+ New registration**
-    1. For **Name**, provide the name for your app. *Tip: Keep things simple by using the `Stack Name` you entered above.*
-    1. For **Who can use this application or access this API?**, choose **Accounts in this organizational directory only (AWS only - Single tenant)**
-    1. Choose **Register**
-    1. *Note down the **Application (client) ID** value, and the **Directory (tenant) ID** from the **Overview** page. You'll need them later when asked for **MicrosoftAppId** and **MicrosoftAppTenantId**.*
-1. In the **Select API permissions** page (on the left navigation menu)
-    1. Choose **Add a permission**
-    1. Choose **Microsoft Graph**
-    1. Choose **Application permissions**
-    1. Select **User.Read.All**
-    1. Select **ChannelMessage.Read.All**
-    1. Select **Team.ReadBasic.All**
-    1. Select **Files.Read.All**
-    1. Choose **Add permissions**. *This permission allows the app to read data in your organization's directory about the signed in user.*
-    1. Remove the original **User.Read - Delegated** permission (use the … menu on the right to choose **Remove permission**)
-    1. Choose **✓ Grant admin consent for Default Directory**
-1. In the **Certificates & secrets** page
-    1. Choose **+ New client secret**
-    1. For **Description**, provide a value such as *<Appname>-client-secret*
-    1. Choose a value for **Expires**. *NOTE: In production, you'll need to manually rotate your secret before it expires.* 
-    1. Choose **Add**
-    1. *Note down the **Value** for your new secret. You'll need it later when asked for **MicrosoftAppPassword**.*
-1. (Optional) Choose **Owners** to add any additional owners for the application.
-
-
-#### 2.2 Register your new app in the Microsoft Bot Framework
+### 5. Register your new app in the Microsoft Bot Framework
 
 1. Go to the Microsoft Bot Framework: https://dev.botframework.com/bots/new - login with your Microsoft account.
-1. (Optional) Create and upload a cool custom icon for your new Amazon Q Bot. Or, use this one that I created using [Amazon Bedrock image playgound](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/image-playground?modelId=stability.stable-diffusion-xl-v1)!  
+1. (Optional) Create and upload a cool custom icon for your new Amazon Q Bot. Or, use this one that I created using [Amazon Bedrock image playground](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/image-playground?modelId=stability.stable-diffusion-xl-v1)!  
       <img src=./images/QBotIcon.png height=70 />  
 1. Enter your prefered **Display name**, **Bot handle**, and **Long description**.    
-1. For **Messaging endpoint** copy and paste the value of the `TeamsEventHandlerApiEndpoint` from your Stack outputs tab (from Step 1).  *Do not check Enable Streaming Endpoint*.   
+1. For **Messaging endpoint** copy and paste the value suffixed with `TeamsEventHandlerApiEndpoint` from your Stack outputs tab (from Step 1).  *Do not check Enable Streaming Endpoint*.   
 1. For **App type**, choose `Single Tenant`.  
 1. For **Paste your app ID below to continue**, enter the *MicrosoftAppId* value you noted above.   
 1. For **App Tenant ID**, enter the *MicrosoftAppTenantId* value you noted above.  
@@ -119,9 +164,9 @@ When your CloudFormation stack status is CREATE_COMPLETE, choose the **Outputs**
 1. Choose **Microsoft Teams Commercial (most common)**, and then **Save**.  
 1. Agree to the Terms of Service and choose **Agree**  
 
-### 3. Configure your Secrets in AWS
+### 6. Configure your Secrets in AWS
 
-Let's configure your App secrets in order to (1) verify the signature of each request, (2) post on behalf of your bot
+#### 6.1 Configure your Teams secrets in order to (1) verify the signature of each request, (2) post on behalf of your bot
 
 > **IMPORTANT**
 > In this example we are not enabling app secret rotation. Enable it for a production app by implementing
@@ -129,16 +174,24 @@ Let's configure your App secrets in order to (1) verify the signature of each re
 > Please create an issue (or, better yet, a pull request!) in this repo if you want this feature added to a future version.
 
 1. Login to your AWS console
-2. In your AWS account go to Secret manager, using the URL shown in the stack output: `TeamsSecretConsoleUrl`.
+2. In your AWS account go to Secret manager, using the URL shown in the stack output suffixed with `TeamsSecretConsoleUrl`.
 3. Choose `Retrieve secret value`
 4. Choose `Edit`
 5. Replace the value of `MicrosoftAppId`, `MicrosoftAppPassword`, and `MicrosoftAppTenantId` with the values you noted in the previous steps.
 6. Choose **Save**
 
-### 4. Finally, deploy into Microsoft Teams
+#### 6.2 Configure OIDC Client Secret in order to exchange the code for token
+
+1. Login to your AWS console
+2. In your AWS account go to Secret manager, using the URL shown in the stack output suffixed with `OIDCClientSecretConsoleUrl`.
+3. Choose `Retrieve secret value`
+4. Choose `Edit`
+5. Replace the value of `OidcClientSecret`, you will find those values in the IdP app client configuration.
+
+### 7. Finally, deploy into Microsoft Teams
 
 1. Go to Developer Portal for Teams: https://dev.teams.microsoft.com/home - login with your Microsoft Teams user account.
-1. Choose **+ New app**
+1. Choose Apps (left side pane) and then **+ New app**
     1. For **Name**, enter your bot name.
     1. Enter **Full name** and both short and full **Descriptions** *(you can just use the bot name for them all if you want - just don't leave them empty)*
     1. Enter values for **Developer information** and **App URLs** fields.
@@ -176,7 +229,10 @@ To use your Amazon Q business expert app in your team channels, first add it to 
 2. Under Apps add your new Amazon Q business expert app to a Chat 
 3. Optionally add your app to one or more Team channels
 4. In the app DM chat, say *Hello*. In a team channel, ask it for help with an @mention.
-5. Enjoy.
+5. You'll be prompted in DM chat to Sign In with your Okta credentials to authenticate with Amazon Q. Click the button to sign in. 
+6. You'll be redirected to browser to sign in with Okta. Once you sign in, you can close the browser window and return to Microsoft Teams.
+7. You're now authenticated and can start asking questions!
+8. Enjoy.
 
 ## Contributing, and reporting issues
 

--- a/README_DEVELOPERS.md
+++ b/README_DEVELOPERS.md
@@ -11,53 +11,214 @@ This Developer README describes how to build the project from the source code - 
 To deploy or to publish, you need to have the following packages installed on your computer:
 
 1. bash shell (Linux, MacOS, Windows-WSL)
-2. node and npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm 
+2. node and npm: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
 3. tsc (typescript): `npm install -g typescript`
 4. esbuild: `npm i -g esbuild`
 5. jq: https://jqlang.github.io/jq/download/
-6. aws (AWS CLI): https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html 
+6. aws (AWS CLI): https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
 7. cdk (AWS CDK): https://docs.aws.amazon.com/cdk/v2/guide/cli.html
 
 Copy the GitHub repo to your computer. Either:
 - use the git command: git clone https://github.com/aws-samples/amazon-q-teams-gateway.git
 - OR, download and expand the ZIP file from the GitHub page: https://github.com/aws-samples/amazon-q-teams-gateway/archive/refs/heads/main.zip
 
+### 2. Prerequisites
+
+1. You need to have an AWS account and an IAM Role/User with permissions to create and manage the necessary resources and components for this application. *(If you do not have an AWS account, please see [How do I create and activate a new Amazon Web Services account?](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/))*
+
+2. You need to have an Okta Workforce Identity Cloud account. If you haven't signed up yet, see [Signing up for Okta](https://www.okta.com/)
+
+3. You need to configure SAML and SCIM with Okta and IAM Identity Center. If you haven't configured, see [Configuring SAML and SCIM with Okta and IAM Identity Center](https://docs.aws.amazon.com/singlesignon/latest/userguide/gs-okta.html)
+
+4. You also need to have an existing, working Amazon Q business application integrated with IdC. If you haven't set one up yet, see [Creating an Amazon Q application](https://docs.aws.amazon.com/amazonq/latest/business-use-dg/create-app.html)
+
+5. You need to have users subscribed to your Amazon Q business application, and are able to access Amazon Q Web Experience. If you haven't set one up yet, see [Subscribing users to an Amazon Q application](https://docs.aws.amazon.com/amazonq/latest/qbusiness-ug/adding-users-groups.html)
+
+6. You have aws cli latest version installed on your Linux or MacOS system. If you haven't installed yet, see [Installing the AWS CLI version 2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+
+7. Lastly, you need a [Microsoft account](https://account.microsoft.com/) and a [Microsoft Teams subscription](https://www.microsoft.com/en-us/microsoft-teams/compare-microsoft-teams-business-options-b) to create and publish the app using the steps below. If you don’t have these, see if your company can create sandboxes for you to experiment, or create a new account and trial subscription as needed to complete the directions below. You will need a Office 365 business subscription for Teams admin privileges. This subscription will also provide a business Microsoft account which will be needed since some steps cannot use an account with a personal email address.
+
 ## Deploy the solution
 
-Before starting, you need to have an existing, working Amazon Q application. If you haven't set one up yet, see [Creating an Amazon Q application](https://docs.aws.amazon.com/amazonq/latest/business-use-dg/create-app.html)
+### 1. Setup
 
-### 1. Initialize and deploy the stack
+#### 1.1 Create an OIDC app integration, for the gateway, in Okta.
+
+Create the client as a ['Web app'](https://help.okta.com/en-us/content/topics/apps/apps_app_integration_wizard_oidc.htm). You will want to enable the 'Refresh Token' grant type, 'Allow everyone in your organization to access', and 'Federation Broker Mode'. Use a placeholder URL, like ```https://example.com```, for the redirect URI, as you will update this later (in step 3).
+
+#### 1.2 Create Trusted token issuer in IAM Identity Center
+
+Create trusted token issuer to trust tokens from OIDC issuer URL using these instructions listed here - https://docs.aws.amazon.com/singlesignon/latest/userguide/using-apps-with-trusted-token-issuer.html.
+Or you can run the below script.
+
+For the script, you need to have the OIDC issuer URL and the AWS region in which you have your Q business application. To retrieve the OIDC issuer URL, go to Okta account console, click the left hamburger menu and open Security > API and copy the whole 'Issuer URI'.
+
+The script will output trusted token issuer ARN (TTI_ARN) which you will use in the next step.
+
+```
+ export AWS_DEFAULT_REGION=<>
+ OIDC_ISSUER_URL=<>
+ bin/create-trusted-token-issuer.sh $OIDC_ISSUER_URL
+```
+
+#### 1.3 Create Customer managed application in IAM Identity Center
+
+Create customer managed IdC application by running below script.
+
+For the script, you need to have the OIDC client ID, trusted token issuer ARN, and the region in which you have your Q business application. To retrieve the OIDC client ID, go to Okta account console, click the left hamburger menu and open Applications > Applications and click on the application you created in step 1.1. Copy the 'Client ID'. For TTI_ARN, you can use the output from the previous step.
+
+The script will output the gateway IdC application ARN (GATEWAY_IDC_ARN) which you will use in the next step.
+
+```
+ export AWS_DEFAULT_REGION=<>
+ OIDC_CLIENT_ID=<>
+ TTI_ARN=<>
+ bin/create-idc-application.sh $OIDC_CLIENT_ID $TTI_ARN
+```
+
+### 2. Register a new app in the Microsoft Azure portal
+
+1. Go to the Azure Portal: https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade and login with your Microsoft account.
+1. Choose **+ New registration**
+   1. For **Name**, provide the name for your app, e.g. AMAZON-Q-TEAMS-GATEWAY.
+   1. For **Who can use this application or access this API?**, choose **Accounts in this organizational directory only (AWS only - Single tenant)**
+   1. Choose **Register**
+   1. *Note down the **Application (client) ID** value, and the **Directory (tenant) ID** from the **Overview** page. You'll need them later when asked for **MicrosoftAppId** and **MicrosoftAppTenantId**.*
+1. In the **API permissions** page (on the left navigation menu)
+   1. Choose **Add a permission**
+   1. Choose **Microsoft Graph**
+   1. Choose **Application permissions**
+   1. Select **User.Read.All**
+   1. Select **ChannelMessage.Read.All**
+   1. Select **Team.ReadBasic.All**
+   1. Select **Files.Read.All**
+   1. Choose **Add permissions**. *This permission allows the app to read data in your organization's directory about the signed in user.*
+   1. Remove the original **User.Read - Delegated** permission (use the … menu on the right to choose **Remove permission**)
+   1. Choose **✓ Grant admin consent for Default Directory**
+1. In the **Certificates & secrets** page
+   1. Choose **+ New client secret**
+   1. For **Description**, provide a value such as *\<Appname\>-client-secret*
+   1. Choose a value for **Expires**. *NOTE: In production, you'll need to manually rotate your secret before it expires.*
+   1. Choose **Add**
+   1. *Note down the **Value** (not Secret ID) for your new secret. You'll need it later when asked for **MicrosoftAppPassword**.*
+1. (Optional) Choose **Owners** to add any additional owners for the application.
+
+### 3. Initialize and deploy the stack
 
 Navigate into the project root directory and, in a bash shell, run:
 
-1. `./init.sh` - checks your system dependendencies for required packages (see Dependencies above), sets up your environment file, and bootstraps your cdk environment.
+1. `./init.sh` - checks your system dependencies for required packages (see Dependencies above), sets up your environment file, and bootstraps your cdk environment.
 2. `./deploy.sh` - runs the cdk build and deploys or updates a stack in your AWS account, and outputs value that you'll need in the next section:
-- url for EventHandler API endpoint  
-- link to the AWS Secrets Manager secret
+- url for EventHandler API endpoint
+- links to the AWS Secrets Manager secrets
 
-### 3. Configure your Teams application
+### 4. Update OIDC Client Redirect URL.
 
-Refer to [README](./README.md#2-configure-your-teams-bot-application)
+Go the app client settings created in IdP (in step 1.1), and update the client signin redirect URL with exported value in Cloudformation stack for the output with suffix `OIDCCallbackEndpointExportedName`.
 
+### 5. Register your new app in the Microsoft Bot Framework
+
+1. Go to the Microsoft Bot Framework: https://dev.botframework.com/bots/new - login with your Microsoft account.
+1. (Optional) Create and upload a cool custom icon for your new Amazon Q Bot. Or, use this one that I created using [Amazon Bedrock image playground](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/image-playground?modelId=stability.stable-diffusion-xl-v1)!  
+   <img src=./images/QBotIcon.png height=70 />
+1. Enter your prefered **Display name**, **Bot handle**, and **Long description**.
+1. For **Messaging endpoint** copy and paste the value suffixed with `TeamsEventHandlerApiEndpoint` from your Stack outputs tab (from Step 1).  *Do not check Enable Streaming Endpoint*.
+1. For **App type**, choose `Single Tenant`.
+1. For **Paste your app ID below to continue**, enter the *MicrosoftAppId* value you noted above.
+1. For **App Tenant ID**, enter the *MicrosoftAppTenantId* value you noted above.
+1. Leave the other values as they are, agree to the terms, and choose **Register**.
+1. On the **Channels** page, under **Add a featured channel** choose **Microsoft Teams**
+1. Choose **Microsoft Teams Commercial (most common)**, and then **Save**.
+1. Agree to the Terms of Service and choose **Agree**
+
+### 6. Configure your Secrets in AWS
+
+#### 6.1 Configure your Teams secrets in order to (1) verify the signature of each request, (2) post on behalf of your bot
+
+> **IMPORTANT**
+> In this example we are not enabling app secret rotation. Enable it for a production app by implementing
+> rotation via AWS Secrets Manager.
+> Please create an issue (or, better yet, a pull request!) in this repo if you want this feature added to a future version.
+
+1. Login to your AWS console
+2. In your AWS account go to Secret manager, using the URL shown in the stack output suffixed with `TeamsSecretConsoleUrl`.
+3. Choose `Retrieve secret value`
+4. Choose `Edit`
+5. Replace the value of `MicrosoftAppId`, `MicrosoftAppPassword`, and `MicrosoftAppTenantId` with the values you noted in the previous steps.
+6. Choose **Save**
+
+#### 6.2 Configure OIDC Client Secret in order to exchange the code for token
+
+1. Login to your AWS console
+2. In your AWS account go to Secret manager, using the URL shown in the stack output suffixed with `OIDCClientSecretConsoleUrl`.
+3. Choose `Retrieve secret value`
+4. Choose `Edit`
+5. Replace the value of `OidcClientSecret`, you will find those values in the IdP app client configuration.
+
+### 7. Finally, deploy into Microsoft Teams
+
+1. Go to Developer Portal for Teams: https://dev.teams.microsoft.com/home - login with your Microsoft Teams user account.
+1. Choose Apps (left side pane) and then **+ New app**
+   1. For **Name**, enter your bot name.
+   1. Enter **Full name** and both short and full **Descriptions** *(you can just use the bot name for them all if you want - just don't leave them empty)*
+   1. Enter values for **Developer information** and **App URLs** fields.
+      1. *For testing, you can make up values, and URLs like `https://www.anycompany.com/` etc. Use real ones for production.*
+   1. For **Application (client) ID*** enter the value of `MicrosoftAppId` from above.
+   1. Choose **Save**.
+1. Under **Branding** you can upload my AI generated icons, or different icon(s), or none at all.. it's up to you.
+   - [Color icon 192x192](./images/QBotIcon.png) / [Outline icon 32x32](./images/QBotIcon-small.png)   
+     <img src=./images/QBotIcon-small.png />
+1. Under **App features**, choose **Bot**
+   1. Select **Enter a bot ID**, and enter the `MicrosoftAppId` from the earlier steps
+   1. Under **What can your bot do?**, check **Upload and download files**.
+   1. Under **Select the scopes in which people can use this command**, check all 3 boxes (**Personal**, **Team**, and **Group chat**).
+   1. Choose **Save**
+1. Choose **Publish**
+   1. Choose **Download the app package** to download a zip file to your computer.
+1. Choose **Preview in Teams** to **Microsoft Teams (work or school)** app
+   1. From the Microsoft Teams left navigation bar, choose **Apps**, then **Manage your apps**, then **⤒ Upload an app**
+   1. Choose **Upload an app to your orgs app catalog**, and select the zip file downloaded in the previous step. This adds the app to Teams.
+   1. Select the card for your new app and choose **Add**.
+
+And, now, at last, you can test your bot in Microsoft Teams!
+
+### Add your bot to one or more Teams
+To use your Amazon Q business expert app in your team channels, first add it to each team:
+1. In the Teams app, select your Team and choose 'Manage team'
+2. In the Apps tab, choose the new Amazon Q app, and Add.
+
+![Teams Demo](./images/AddToTeam.png)
+
+### Say hello
+> Time to say Hi!
+
+1. Go to Teams
+2. Under Apps add your new Amazon Q business expert app to a Chat
+3. Optionally add your app to one or more Team channels
+4. In the app DM chat, say *Hello*. In a team channel, ask it for help with an @mention.
+5. You'll be prompted in DM chat to Sign In with your Okta credentials to authenticate with Amazon Q. Click the button to sign in.
+6. You'll be redirected to browser to sign in with Okta. Once you sign in, you can close the browser window and return to Microsoft Teams.
+7. You're now authenticated and can start asking questions!
+8. Enjoy.
 
 ## Publish the solution
 
-In our main README, you will see that we provided Easy Deploy Buttons to launch a stack using pre-built templates that we published already to an S3 bucket. 
+In our main README, you will see that we provided Easy Deploy Buttons to launch a stack using pre-built templates that we published already to an S3 bucket.
 
 If you want to build and publish your own template, to your own S3 bucket, so that others can easily use a similar easy button approach to deploy a stack, using *your* templates, here's how.
 
 Navigate into the project root directory and, in a bash shell, run:
 
 1. `./publish.sh <cfn_bucket_basename> <cfn_prefix> <us-east-1 | us-west-2>`.  
-  This:
-    - checks your system dependendencies for required packages (see Dependencies above)
-    - bootstraps your cdk environment if needed
-    - creates a standalone CloudFormation template (that doesn't depend on CDK)
-    - publishes the template and required assets to an S3 bucket in your account called `cfn_bucket_basename-region` (it creates the bucket if it doesn't already exist)
-    - optionally add a final parameter `public` if you want to make the templates public. Note: your bucket and account must be configured not to Block Public Access using new ACLs.
+   This:
+   - checks your system dependencies for required packages (see Dependencies above)
+   - bootstraps your cdk environment if needed
+   - creates a standalone CloudFormation template (that doesn't depend on CDK)
+   - publishes the template and required assets to an S3 bucket in your account called `cfn_bucket_basename-region` (it creates the bucket if it doesn't already exist)
+   - optionally add a final parameter `public` if you want to make the templates public. Note: your bucket and account must be configured not to Block Public Access using new ACLs.
 
 That's it! There's just one step.
-  
+
 When completed, it displays the CloudFormation templates S3 URLs and 1-click URLs for launching the stack creation in CloudFormation console, e.g.:
 ```
 OUTPUTS
@@ -66,7 +227,7 @@ CF Launch URL: https://us-east-1.console.aws.amazon.com/cloudformation/home?regi
 Done
 ``````
 
-Follow the deployment directions in the main [README](./README.md), but use your own CF Launch URL instead of our pre-built templates (Launch Stack buttons). 
+Follow the deployment directions in the main [README](./README.md), but use your own CF Launch URL instead of our pre-built templates (Launch Stack buttons).
 
 
 ## Contributing, and reporting issues

--- a/bin/convert-cfn-template.js
+++ b/bin/convert-cfn-template.js
@@ -185,13 +185,6 @@ function parameterizeTemplate(template, lambdas) {
   const allowedQRegions = ['us-east-1', 'us-west-2'];
   const defaultQRegion = allowedQRegions.includes(awsRegion) ? awsRegion : allowedQRegions[0];
   template.Parameters = {
-    AmazonQUserId: {
-      Type: 'String',
-      Default: '',
-      AllowedPattern: '(|^[\\w.+-]+@([\\w-]+\\.)+[\\w-]{2,6}$)',
-      Description:
-        '(Optional) Amazon Q User ID email address (leave empty to use Teams users email as user Id)'
-    },
     AmazonQAppId: {
       Type: 'String',
       AllowedPattern: '^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$',
@@ -208,16 +201,50 @@ function parameterizeTemplate(template, lambdas) {
       Default: 90,
       MinValue: 1,
       Description: 'Number of days to keep conversation context'
+    },
+    OIDCIdPName: {
+      Type: 'String',
+      Default: 'Okta',
+      AllowedPattern: '^[a-zA-Z]{1,255}$',
+      Description: 'Name of Identity Provider (Okta, Cognito, Other)'
+    },
+    OIDCClientId: {
+      Type: 'String',
+      AllowedPattern: '^[a-zA-Z0-9]{1,255}$',
+      Description: 'OIDC Client ID'
+    },
+    OIDCIssuerURL: {
+      Type: 'String',
+      AllowedPattern: '^https://[a-zA-Z0-9.-]+(:[0-9]+)?(/.*)?$',
+      Description: 'OIDC Issuer URL'
+    },
+    GatewayIdCAppARN: {
+      Type: 'String',
+      AllowedPattern: '^arn:aws[a-zA-Z-]*:[a-zA-Z0-9-]*:[a-z0-9-]*:[0-9]{12}:[a-zA-Z0-9:/._-]+$',
+      Description: 'Q Business Teams Gateway IdC App Arn'
+    },
+    MicrosoftAppId: {
+      Type: 'String',
+      AllowedPattern: '^[a-zA-Z0-9-]{1,64}$',
+      Description: 'Microsoft Teams Bot App ID (copy from Azure portal)'
     }
   };
   for (let lambda of lambdas) {
     let lambdaResource = template.Resources[lambda.resourceName];
     lambdaResource.Properties.Environment.Variables.AMAZON_Q_ENDPOINT = ''; // use default endpoint
-    lambdaResource.Properties.Environment.Variables.AMAZON_Q_USER_ID = { Ref: 'AmazonQUserId' };
     lambdaResource.Properties.Environment.Variables.AMAZON_Q_APP_ID = { Ref: 'AmazonQAppId' };
     lambdaResource.Properties.Environment.Variables.AMAZON_Q_REGION = { Ref: 'AmazonQRegion' };
     lambdaResource.Properties.Environment.Variables.CONTEXT_DAYS_TO_LIVE = {
       Ref: 'ContextDaysToLive'
+    };
+    lambdaResource.Properties.Environment.Variables.OIDC_IDP_NAME = { Ref: 'OIDCIdPName' };
+    lambdaResource.Properties.Environment.Variables.OIDC_CLIENT_ID = { Ref: 'OIDCClientId' };
+    lambdaResource.Properties.Environment.Variables.OIDC_ISSUER_URL = { Ref: 'OIDCIssuerURL' };
+    lambdaResource.Properties.Environment.Variables.GATEWAY_IDC_APP_ARN = {
+      Ref: 'GatewayIdCAppARN'
+    };
+    lambdaResource.Properties.Environment.Variables.MICROSOFT_APP_ID = {
+      Ref: 'MicrosoftAppId'
     };
   }
 }

--- a/bin/create-idc-application.sh
+++ b/bin/create-idc-application.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# Ensure required arguments are passed
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <oidc_client_id> <trusted-token-issuer-arn> [application_name]"
+    exit 1
+else
+    OIDC_CLIENT_ID="$1"
+    TTI_ARN="$2"
+    if [ -n "$3" ]; then
+        APPLICATION_NAME="$3"
+    else
+        APPLICATION_NAME="AmazonQTeamsGateway"
+    fi
+fi
+
+# Retrieve AWS Account ID
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+if [ $? -ne 0 ]; then
+    echo "Failed to retrieve AWS account ID."
+    exit 1
+fi
+
+# Get instance ARN
+IDC_INSTANCE_ARN=$(aws sso-admin list-instances --query 'Instances[0].InstanceArn' | tr -d '""')
+if [ $? -ne 0 ] || [ -z "$IDC_INSTANCE_ARN" ]; then
+    echo "Error: IDC_INSTANCE_ARN is empty or failed to retrieve. Please check your AWS SSO configuration."
+    exit 1
+fi
+
+# Check if the application already exists
+echo "Checking if the $APPLICATION_NAME exists..."
+APPLICATION_EXISTS=0
+GATEWAY_IDC_ARN=""
+RESPONSE=$(aws sso-admin list-applications --instance-arn $IDC_INSTANCE_ARN --query '{"ApplicationArn": Applications[*].ApplicationArn, "NextToken": NextToken}')
+NEXT_TOKEN=$(echo $RESPONSE | jq -r '.NextToken')
+APPLICATION_ARNS=$(echo $RESPONSE | jq -r '.ApplicationArn[] | []')
+echo $APPLCIATION_ARNS
+for ARN in $(echo $RESPONSE | jq -r -c '.ApplicationArn' | tr -d '[]"' | sed 's/,/ /g'); do
+    CURRENT_NAME=$(aws sso-admin describe-application --application-arn $ARN --query 'Name' | tr -d '"')
+    if [ "$CURRENT_NAME" == "$APPLICATION_NAME" ]; then
+        GATEWAY_IDC_ARN=$ARN
+        APPLICATION_EXISTS=1
+        echo "$APPLICATION_NAME already exists with GATEWAY_IDC_ARN: $GATEWAY_IDC_ARN"
+    fi
+done
+#
+# Create the application if it does not exist
+CUSTOM_APPLICATION_PROVIDER_ARN="arn:aws:sso::aws:applicationProvider/custom"
+if [ $APPLICATION_EXISTS -eq 0 ]; then
+    GATEWAY_IDC_ARN=$(aws sso-admin create-application --application-provider-arn $CUSTOM_APPLICATION_PROVIDER_ARN --instance-arn $IDC_INSTANCE_ARN --name "$APPLICATION_NAME" --query 'ApplicationArn' | tr -d '"')
+    if [ $? -ne 0 ] || [ -z "$GATEWAY_IDC_ARN" ]; then
+        echo "Error: GATEWAY_IDC_ARN could not be created. Please check your inputs and AWS permissions."
+        exit 1
+    fi
+    echo "Created GATEWAY_IDC_ARN: $GATEWAY_IDC_ARN"
+fi
+
+# Disable assignment
+aws sso-admin put-application-assignment-configuration --application-arn $GATEWAY_IDC_ARN --no-assignment-required
+if [ $? -ne 0 ]; then
+    echo "Failed to disable assignment for the application."
+    exit 1
+fi
+
+# Put grant
+json_input='{
+    "ApplicationArn": "'$GATEWAY_IDC_ARN'",
+    "Grant": {
+        "JwtBearer": {
+            "AuthorizedTokenIssuers": [
+                {
+                    "AuthorizedAudiences": [
+                        "'$OIDC_CLIENT_ID'" 
+                    ],
+                    "TrustedTokenIssuerArn": "'$TTI_ARN'" 
+                }
+            ]
+        }
+    },
+    "GrantType": "urn:ietf:params:oauth:grant-type:jwt-bearer"
+}'
+aws sso-admin put-application-grant --cli-input-json "$json_input"
+if [ $? -ne 0 ]; then
+    echo "Failed to put application grant."
+    exit 1
+fi
+
+# Put application authentication method
+json_input='{
+    "ApplicationArn": "'$GATEWAY_IDC_ARN'",
+    "AuthenticationMethod": {
+        "Iam": {
+            "ActorPolicy": {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "AWS": "'$AWS_ACCOUNT_ID'" 
+                        },
+                        "Action": "sso-oauth:CreateTokenWithIAM",
+                        "Resource": "*"
+                    }
+                ]
+            }
+        }
+    },
+    "AuthenticationMethodType": "IAM"
+}'
+aws sso-admin put-application-authentication-method --cli-input-json "$json_input"
+if [ $? -ne 0 ]; then
+    echo "Failed to set authentication method."
+    exit 1
+fi
+
+# Put application access scopes
+if ! aws sso-admin put-application-access-scope --application-arn $GATEWAY_IDC_ARN --scope "qbusiness:conversations:access"; then
+    echo "Failed to set access scope for conversations."
+    exit 1
+fi
+if ! aws sso-admin put-application-access-scope --application-arn $GATEWAY_IDC_ARN --scope "qbusiness:messages:access"; then
+    echo "Failed to set access scope for messages."
+    exit 1
+fi
+
+# Echo GATEWAY_IDC_ARN at the end
+echo "$APPLICATION_NAME is setup with GATEWAY_IDC_ARN: $GATEWAY_IDC_ARN"
+

--- a/bin/create-trusted-token-issuer.sh
+++ b/bin/create-trusted-token-issuer.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Ensure required arguments are passed
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <oidc_issuer_url>"
+    exit 1
+fi
+
+OIDC_ISSUER_URL="$1"
+
+# Input
+IDC_INSTANCE_ARN=$(aws sso-admin list-instances --query 'Instances[0].InstanceArn' | tr -d '"')
+
+# Check if there is TTI_ARN for the issuer url.
+for arn in $(aws sso-admin list-trusted-token-issuers --instance-arn $IDC_INSTANCE_ARN --query 'TrustedTokenIssuers[].TrustedTokenIssuerArn[]' | tr -d '[",]')
+do
+    current_issuer_url=$(aws sso-admin describe-trusted-token-issuer --trusted-token-issuer-arn $arn --query 'TrustedTokenIssuerConfiguration.OidcJwtConfiguration.IssuerUrl' --output text)
+    if [[ "$current_issuer_url" == "$OIDC_ISSUER_URL" ]]
+    then
+        echo "Trusted token issuer already exists for $OIDC_ISSUER_URL, ARN: $arn"
+        exit 0
+    fi
+done
+
+# Create Trusted token issuer
+TTI_ARN=$(aws sso-admin create-trusted-token-issuer --cli-input-json '{
+    "InstanceArn": '\"$IDC_INSTANCE_ARN\"',
+    "Name": "okta-issuer",
+    "TrustedTokenIssuerConfiguration": {
+        "OidcJwtConfiguration": {
+            "ClaimAttributePath": "email",
+            "IdentityStoreAttributePath": "emails.value",
+            "IssuerUrl": '\"$OIDC_ISSUER_URL\"',
+            "JwksRetrievalOption": "OPEN_ID_DISCOVERY"
+        }
+    },
+    "TrustedTokenIssuerType": "OIDC_JWT"
+}' --query 'TrustedTokenIssuerArn' | tr -d '"')
+
+echo "TTI_ARN=$TTI_ARN"

--- a/bin/environment.sh
+++ b/bin/environment.sh
@@ -4,6 +4,8 @@
 # helper script called by $ROOT/init.sh - interactively create environment.json
 #
 
+echo "This script will interactively create or update environment.json"
+
 json_file="environment.json"
 
 prompt_for_value() {
@@ -40,7 +42,7 @@ prompt_for_value() {
     elif [[ $value =~ $regex ]]; then
       # value matches the regex - all good.
       break
-    else 
+    else
       # value does not match the regex.. ask user to try again
       echo "Value entered does not match required regex: $regex. Please enter a valid value." >&2
     fi
@@ -50,12 +52,16 @@ prompt_for_value() {
 }
 
 # Read or update values
-stack_name=$(prompt_for_value "StackName" "Name for slack bot" "AmazonQBot" "^[A-Za-z][A-Za-z0-9-]{0,127}$")
+stack_name=$(prompt_for_value "StackName" "Name for teams bot" "AmazonQBot" "^[A-Za-z][A-Za-z0-9-]{0,127}$")
+bot_app_id=$(prompt_for_value "MicrosoftAppId" "Microsoft Teams Bot App ID (copy from Azure portal)" "none" "^[a-zA-Z0-9-]{1,64}$")
 # From Bash 3 - testing with MacOS - m and n must be in the range from 0 to RE_DUP_MAX (default 255), inclusive.
-user_id=$(prompt_for_value "AmazonQUserId" "Amazon Q User ID (leave empty to use slack users' email as user Id)" "" "^[^[:space:]]{0,255}$")
 app_id=$(prompt_for_value "AmazonQAppId" "Amazon Q Application ID (copy from AWS console)" "none" "^[a-zA-Z0-9][a-zA-Z0-9-]{35}$")
 region=$(prompt_for_value "AmazonQRegion" "Amazon Q Region" $(aws configure get region) "^[a-z]{2}-[a-z]+-[0-9]+$")
 ttl_days=$(prompt_for_value "ContextDaysToLive" "Number of days to keep conversation context" "90" "^[1-9][0-9]{0,3}$")
+oidc_idp_name=$(prompt_for_value "OIDCIdPName" "Name of Identity Provider (Okta, Cognito, Other)" "Okta" "^[a-zA-Z]{1,255}$")
+oidc_client_id=$(prompt_for_value "OIDCClientId" "OIDC Client ID" "none" "^[a-zA-Z0-9]{1,255}$")
+oidc_issuer_url=$(prompt_for_value "OIDCIssuerURL" "OIDC Issuer URL" "none" "^https://[a-zA-Z0-9.-]+(:[0-9]+)?(/.*)?$")
+gateway_idc_app_arn=$(prompt_for_value "GatewayIdCAppARN" "Q Gateway IdC App Arn" "none" "^arn:aws[a-zA-Z-]*:[a-zA-Z0-9-]*:[a-z0-9-]*:[0-9]{12}:[a-zA-Z0-9:/._-]+$")
 
 # Create or update the JSON file
 cp $json_file $json_file.bak 2> /dev/null
@@ -63,14 +69,22 @@ jq -n \
   --arg stack_name "$stack_name" \
   --arg app_id "$app_id" \
   --arg region "$region" \
-  --arg user_id "$user_id" \
   --arg ttl_days "$ttl_days" \
+  --arg oidc_idp_name "$oidc_idp_name" \
+  --arg oidc_client_id "$oidc_client_id" \
+  --arg oidc_issuer_url "$oidc_issuer_url" \
+  --arg gateway_idc_app_arn "$gateway_idc_app_arn" \
+  --arg bot_app_id "$bot_app_id" \
   '{
     StackName: $stack_name,
     AmazonQAppId: $app_id,
-    AmazonQUserId: $user_id,
     AmazonQRegion: $region,
-    ContextDaysToLive: $ttl_days
+    ContextDaysToLive: $ttl_days,
+    OIDCIdPName: $oidc_idp_name,
+    OIDCClientId: $oidc_client_id,
+    OIDCIssuerURL: $oidc_issuer_url,
+    GatewayIdCAppARN: $gateway_idc_app_arn,
+    MicrosoftAppId: $bot_app_id
   }' > "$json_file"
 
 echo "Configuration saved to $json_file"

--- a/bin/my-amazon-q-teams-bot.ts
+++ b/bin/my-amazon-q-teams-bot.ts
@@ -7,9 +7,13 @@ import { readFileSync } from 'fs';
 export interface StackEnvironment {
   StackName: string;
   AmazonQAppId: string;
-  AmazonQUserId: string;
   AmazonQRegion: string;
   ContextDaysToLive: string;
+  OIDCIdPName: string;
+  OIDCClientId: string;
+  OIDCIssuerURL: string;
+  GatewayIdCAppARN: string;
+  MicrosoftAppId: string;
 }
 
 const app = new cdk.App();
@@ -28,11 +32,23 @@ if (environment.AmazonQAppId === undefined) {
 if (environment.AmazonQRegion === undefined) {
   throw new Error('AmazonQRegion is required');
 }
-if (environment.AmazonQUserId === undefined) {
-  throw new Error('AmazonQUserId is required');
-}
 if (environment.ContextDaysToLive === undefined) {
   throw new Error('ContextDaysToLive is required');
+}
+if (environment.OIDCIdPName === undefined) {
+  throw new Error('OIDCIdPName is required');
+}
+if (environment.OIDCClientId === undefined) {
+  throw new Error('OIDCClientId is required');
+}
+if (environment.OIDCIssuerURL === undefined) {
+  throw new Error('OIDCIssuerURL is required');
+}
+if (environment.GatewayIdCAppARN === undefined) {
+  throw new Error('GatewayIdCAppARN is required');
+}
+if (environment.MicrosoftAppId === undefined) {
+  throw new Error('MicrosoftAppId is required');
 }
 
 new MyAmazonQTeamsBotStack(

--- a/lib/my-amazon-q-teams-bot-stack.ts
+++ b/lib/my-amazon-q-teams-bot-stack.ts
@@ -1,6 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
-import { CfnOutput } from 'aws-cdk-lib';
-import { Duration } from 'aws-cdk-lib';
+import { CfnOutput, Duration } from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda-nodejs';
 import { LambdaRestApi } from 'aws-cdk-lib/aws-apigateway';
 import { Construct } from 'constructs';
@@ -9,6 +8,9 @@ import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 
 import {
+  AccountPrincipal,
+  ArnPrincipal,
+  Effect,
   ManagedPolicy,
   PolicyDocument,
   PolicyStatement,
@@ -18,6 +20,7 @@ import {
 import { StackEnvironment } from '../bin/my-amazon-q-teams-bot';
 
 import * as fs from 'fs';
+import { Key, KeyUsage } from 'aws-cdk-lib/aws-kms';
 const packageJson = fs.readFileSync('package.json', 'utf-8');
 const version = JSON.parse(packageJson).version;
 const STACK_DESCRIPTION = `Amazon Q Teams Gateway - v${version}`;
@@ -34,7 +37,7 @@ export class MyAmazonQTeamsBotStack extends cdk.Stack {
 
     const vpc = new Vpc(this, `${props.stackName}-VPC`);
 
-    const initialSecretContent = JSON.stringify({
+    const initialTeamsSecretContent = JSON.stringify({
       MicrosoftAppId: '<Replace with AppId>',
       MicrosoftAppPassword: '<Replace with AppClientSecret>',
       MicrosoftAppTenantId: '<Replace with TenantId>',
@@ -42,14 +45,36 @@ export class MyAmazonQTeamsBotStack extends cdk.Stack {
     });
     const teamsSecret = new Secret(this, `${props.stackName}-Secret`, {
       secretName: `${refStackName}-Secret`,
-      secretStringValue: cdk.SecretValue.unsafePlainText(initialSecretContent)
+      secretStringValue: cdk.SecretValue.unsafePlainText(initialTeamsSecretContent)
     });
+
+    const initialOIDCClientSecretContent = JSON.stringify({
+      OIDCClientSecret: '<Replace with Client Secret>'
+    });
+    const oidcClientSecret = new Secret(this, `${props.stackName}-OidcClientCredentials`, {
+      secretName: `${refStackName}-OidcClientSecret`,
+      secretStringValue: cdk.SecretValue.unsafePlainText(initialOIDCClientSecretContent)
+    });
+
+    // create KMS key
+    const kmsKey = new Key(this, `${props.stackName}-KmsKey`, {
+      keyUsage: KeyUsage.ENCRYPT_DECRYPT,
+      enableKeyRotation: true,
+      removalPolicy: cdk.RemovalPolicy.DESTROY
+    });
+
     // Output URL to the secret in the AWS Management Console
-    new CfnOutput(this, 'TeamsSecretConsoleUrl', {
+    new CfnOutput(this, `${props.stackName}-TeamsSecretConsoleUrl`, {
       value: `https://${this.region}.console.aws.amazon.com/secretsmanager/secret?name=${teamsSecret.secretName}&region=${this.region}`,
       description: 'Click to edit the secrets in the AWS Secrets Manager console'
     });
 
+    new CfnOutput(this, `${props.stackName}-OIDCClientSecretConsoleUrl`, {
+      value: `https://${this.region}.console.aws.amazon.com/secretsmanager/secret?name=${oidcClientSecret.secretName}&region=${this.region}`,
+      description: 'Click to edit the OIDC client secret in the AWS Secrets Manager console'
+    });
+
+    const OIDC_CALLBACK_API_EXPORTED_NAME = `${props.stackName}-OIDCCallbackEndpointExportedName`;
     const dynamoCache = new Table(this, `${props.stackName}-DynamoCache`, {
       tableName: `${refStackName}-channels-metadata`,
       partitionKey: {
@@ -68,6 +93,214 @@ export class MyAmazonQTeamsBotStack extends cdk.Stack {
       },
       timeToLiveAttribute: 'expireAt',
       removalPolicy: cdk.RemovalPolicy.DESTROY
+    });
+
+    const oidcState = new Table(this, `${props.stackName}-OidcStateTable`, {
+      tableName: `${refStackName}-oidc-state`,
+      partitionKey: {
+        name: 'state',
+        type: AttributeType.STRING
+      },
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      timeToLiveAttribute: 'ttl'
+    });
+
+    const iamSessionCredentials = new Table(this, `${props.stackName}-IamSessionCredentialsTable`, {
+      tableName: `${refStackName}-iam-session-credentials`,
+      partitionKey: {
+        name: 'teamsUserId',
+        type: AttributeType.STRING
+      },
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      timeToLiveAttribute: 'ttl'
+    });
+
+    const qUserAPIRoleName = `${refStackName}-QBusinessRole`;
+    const qUserAPIRoleARN = `arn:aws:iam::${this.account}:role/${qUserAPIRoleName}`;
+
+    const oidcCallbackLambdaExecutionRole = new Role(
+      this,
+      `${props.stackName}-OIDCCallbackLambdaExecutionRole`,
+      {
+        assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+        managedPolicies: [
+          ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole')
+        ],
+        inlinePolicies: {
+          SecretManagerPolicy: new PolicyDocument({
+            statements: [
+              new PolicyStatement({
+                actions: ['secretsmanager:GetSecretValue'],
+                resources: [teamsSecret.secretArn, oidcClientSecret.secretArn]
+              })
+            ]
+          }),
+          DynamoDBPolicy: new PolicyDocument({
+            statements: [
+              new PolicyStatement({
+                actions: ['dynamodb:DeleteItem', 'dynamodb:PutItem', 'dynamodb:GetItem'],
+                resources: [oidcState.tableArn, iamSessionCredentials.tableArn]
+              })
+            ]
+          }),
+          KmsPolicy: new PolicyDocument({
+            statements: [
+              new PolicyStatement({
+                actions: ['kms:Decrypt', 'kms:Encrypt', 'kms:GenerateDataKey'],
+                resources: [kmsKey.keyArn]
+              })
+            ]
+          }),
+          SSOOIDCPolicy: new PolicyDocument({
+            statements: [
+              new PolicyStatement({
+                actions: ['sso-oauth:CreateTokenWithIAM'],
+                resources: ['*'] // env.GatewayIdCAppARN
+              })
+            ]
+          }),
+          StsPolicy: new PolicyDocument({
+            statements: [
+              new PolicyStatement({
+                actions: ['sts:AssumeRole', 'sts:SetContext'],
+                resources: [qUserAPIRoleARN]
+              })
+            ]
+          }),
+          CloudFormationPolicy: new PolicyDocument({
+            statements: [
+              new PolicyStatement({
+                actions: ['cloudformation:ListExports'],
+                resources: ['*']
+              })
+            ]
+          })
+        }
+      }
+    );
+
+    const teamsLambdaExecutionRole = new Role(this, `${props.stackName}-TeamsLambdaExecutionRole`, {
+      assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+      managedPolicies: [
+        ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole')
+      ],
+      inlinePolicies: {
+        SecretManagerPolicy: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ['secretsmanager:GetSecretValue'],
+              resources: [teamsSecret.secretArn, oidcClientSecret.secretArn]
+            })
+          ]
+        }),
+        DynamoDBPolicy: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ['dynamodb:DeleteItem', 'dynamodb:PutItem', 'dynamodb:GetItem'],
+              resources: [
+                dynamoCache.tableArn,
+                messageMetadata.tableArn,
+                oidcState.tableArn,
+                iamSessionCredentials.tableArn
+              ]
+            })
+          ]
+        }),
+        ChatPolicy: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ['qbusiness:ChatSync', 'qbusiness:PutFeedback'],
+              // parametrized
+              resources: [`arn:aws:qbusiness:*:*:application/${env.AmazonQAppId}`]
+            })
+          ]
+        }),
+        SSOOIDCPolicy: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ['sso-oauth:CreateTokenWithIAM'],
+              resources: ['*'] // TODO use fine grained permissions
+            })
+          ]
+        }),
+        KmsPolicy: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ['kms:Decrypt', 'kms:Encrypt', 'kms:GenerateDataKey'],
+              resources: [kmsKey.keyArn]
+            })
+          ]
+        }),
+        StsPolicy: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ['sts:AssumeRole', 'sts:SetContext'],
+              resources: [qUserAPIRoleARN]
+            })
+          ]
+        })
+      }
+    });
+
+    // create a role to trust lambda roles to assume and have permissions to call qbusiness API
+    const qUserAPIRole = new Role(this, `${props.stackName}-QBusinessRole`, {
+      roleName: qUserAPIRoleName,
+      assumedBy: new AccountPrincipal(this.account),
+      inlinePolicies: {
+        ChatPolicy: new PolicyDocument({
+          statements: [
+            new PolicyStatement({
+              actions: ['qbusiness:ChatSync', 'qbusiness:PutFeedback'],
+              resources: ['arn:aws:qbusiness:*:*:application/*']
+            })
+          ]
+        })
+      }
+    });
+
+    const trustPolicy = new PolicyStatement({
+      sid: 'QGatewayTrustPolicy',
+      effect: Effect.ALLOW,
+      principals: [
+        new ArnPrincipal(oidcCallbackLambdaExecutionRole.roleArn),
+        new ArnPrincipal(teamsLambdaExecutionRole.roleArn)
+      ],
+      actions: ['sts:AssumeRole', 'sts:SetContext']
+    });
+    qUserAPIRole.assumeRolePolicy?.addStatements(new PolicyStatement(trustPolicy));
+
+    // Create OIDC callback API Gateway endpoint
+    const oidcCallbackApi = new LambdaRestApi(this, `${props.stackName}-OIDCCallbackApi`, {
+      handler: new lambda.NodejsFunction(this, `${props.stackName}-OIDCCallbackFn`, {
+        functionName: `${refStackName}-OIDCCallback`,
+        entry: 'src/functions/oidc-callback-handler.ts',
+        handler: 'handler',
+        description: 'Handler for OIDC callback',
+        timeout: Duration.seconds(30),
+        environment: {
+          CFN_STACK_NAME: env.StackName,
+          CALLBACK_API_ENDPOINT_EXPORTED_NAME: OIDC_CALLBACK_API_EXPORTED_NAME,
+          AMAZON_Q_REGION: env.AmazonQRegion,
+          OIDC_CLIENT_SECRET_NAME: oidcClientSecret.secretName,
+          OIDC_STATE_TABLE_NAME: oidcState.tableName,
+          IAM_SESSION_CREDENTIALS_TABLE_NAME: iamSessionCredentials.tableName,
+          OIDC_IDP_NAME: env.OIDCIdPName,
+          OIDC_CLIENT_ID: env.OIDCClientId,
+          OIDC_ISSUER_URL: env.OIDCIssuerURL,
+          KEY_ARN: kmsKey.keyArn,
+          Q_USER_API_ROLE_ARN: qUserAPIRole.roleArn,
+          GATEWAY_IDC_APP_ARN: env.GatewayIdCAppARN,
+          MICROSOFT_APP_ID: env.MicrosoftAppId,
+        },
+        role: oidcCallbackLambdaExecutionRole,
+        vpc
+      })
+    });
+
+    new CfnOutput(this, OIDC_CALLBACK_API_EXPORTED_NAME, {
+      exportName: OIDC_CALLBACK_API_EXPORTED_NAME,
+      value: oidcCallbackApi.url,
+      description: 'OIDC Callback API endpoint'
     });
 
     [
@@ -90,46 +323,24 @@ export class MyAmazonQTeamsBotStack extends cdk.Stack {
           timeout: Duration.seconds(30),
           environment: {
             TEAMS_SECRET_NAME: teamsSecret.secretName,
+            OIDC_CLIENT_SECRET_NAME: oidcClientSecret.secretName,
             AMAZON_Q_REGION: env.AmazonQRegion,
             AMAZON_Q_APP_ID: env.AmazonQAppId,
-            AMAZON_Q_USER_ID: env.AmazonQUserId ?? '',
             CONTEXT_DAYS_TO_LIVE: env.ContextDaysToLive,
             CACHE_TABLE_NAME: dynamoCache.tableName,
-            MESSAGE_METADATA_TABLE_NAME: messageMetadata.tableName
+            MESSAGE_METADATA_TABLE_NAME: messageMetadata.tableName,
+            OIDC_STATE_TABLE_NAME: oidcState.tableName,
+            IAM_SESSION_CREDENTIALS_TABLE_NAME: iamSessionCredentials.tableName,
+            OIDC_IDP_NAME: env.OIDCIdPName,
+            OIDC_CLIENT_ID: env.OIDCClientId,
+            OIDC_ISSUER_URL: env.OIDCIssuerURL,
+            OIDC_REDIRECT_URL: oidcCallbackApi.url,
+            KEY_ARN: kmsKey.keyArn,
+            Q_USER_API_ROLE_ARN: qUserAPIRole.roleArn,
+            GATEWAY_IDC_APP_ARN: env.GatewayIdCAppARN,
+            MICROSOFT_APP_ID: env.MicrosoftAppId,
           },
-          role: new Role(this, `${prefix}-Role`, {
-            assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
-            managedPolicies: [
-              ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSLambdaVPCAccessExecutionRole')
-            ],
-            inlinePolicies: {
-              SecretManagerPolicy: new PolicyDocument({
-                statements: [
-                  new PolicyStatement({
-                    actions: ['secretsmanager:GetSecretValue'],
-                    resources: [teamsSecret.secretArn]
-                  })
-                ]
-              }),
-              DynamoDBPolicy: new PolicyDocument({
-                statements: [
-                  new PolicyStatement({
-                    actions: ['dynamodb:DeleteItem', 'dynamodb:PutItem', 'dynamodb:GetItem'],
-                    resources: [dynamoCache.tableArn, messageMetadata.tableArn]
-                  })
-                ]
-              }),
-              ChatPolicy: new PolicyDocument({
-                statements: [
-                  new PolicyStatement({
-                    actions: ['qbusiness:ChatSync', 'qbusiness:PutFeedback'],
-                    // parametrized
-                    resources: [`arn:aws:qbusiness:*:*:application/${env.AmazonQAppId}`]
-                  })
-                ]
-              })
-            }
-          }),
+          role: teamsLambdaExecutionRole,
           vpc
         })
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my_amazon_q_teams_bot",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my_amazon_q_teams_bot",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@aws-crypto/client-node": "^4.0.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,12 @@
       "name": "my_amazon_q_teams_bot",
       "version": "0.1.1",
       "dependencies": {
+        "@aws-crypto/client-node": "^4.0.0",
         "@aws-sdk/client-cloudformation": "^3.465.0",
-        "@aws-sdk/client-qbusiness": "^3.470.0",
+        "@aws-sdk/client-dynamodb": "^3.574.0",
+        "@aws-sdk/client-qbusiness": "^3.574.0",
         "@aws-sdk/client-s3": "^3.465.0",
+        "@aws-sdk/client-sso-oidc": "^3.574.0",
         "@aws-sdk/lib-dynamodb": "^3.465.0",
         "@azure/msal-node": "^2.6.0",
         "@types/aws-lambda": "^8.10.119",
@@ -18,7 +21,7 @@
         "archiver": "^6.0.1",
         "aws-cdk-lib": "^2.110.1",
         "aws-sdk": "^2.1452.0",
-        "botbuilder": "4.21.3",
+        "botbuilder": "^4.21.3",
         "constructs": "^10.0.0",
         "express": "^4.18.2",
         "html-to-text": "^9.0.5",
@@ -92,6 +95,59 @@
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
       "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
     },
+    "node_modules/@aws-crypto/cache-material": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/cache-material/-/cache-material-4.0.0.tgz",
+      "integrity": "sha512-14m9QPzgMJZ2QdbiM7LCMKgqmONx+/9+Zm5YlXJmhP6Ue+qgniCs5MBOT99WKF50sihcjlA8cVbOUBBJh9t1mg==",
+      "dependencies": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "@types/lru-cache": "^5.1.0",
+        "lru-cache": "^6.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/cache-material/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-crypto/cache-material/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/@aws-crypto/caching-materials-manager-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/caching-materials-manager-node/-/caching-materials-manager-node-4.0.0.tgz",
+      "integrity": "sha512-uPhbFMyiHImEsYIZRuzwMO/VS/tzdUMKCN+p9/Hg5I2r97riqPU5ukfjA8whAsVygGNWRuhlnrwBdjwRE+MZuw==",
+      "dependencies": {
+        "@aws-crypto/cache-material": "^4.0.0",
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/client-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/client-node/-/client-node-4.0.0.tgz",
+      "integrity": "sha512-hsYDRSY2MSaAS5AcToR4oSS3sZINVXlOIutJzNkLSLEJuiYwiycJJrILRDCQJk+G6XhT7oJeqbmxFjRA7X83KA==",
+      "dependencies": {
+        "@aws-crypto/caching-materials-manager-node": "^4.0.0",
+        "@aws-crypto/decrypt-node": "^4.0.0",
+        "@aws-crypto/encrypt-node": "^4.0.0",
+        "@aws-crypto/kms-keyring-node": "^4.0.0",
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/raw-aes-keyring-node": "^4.0.0",
+        "@aws-crypto/raw-rsa-keyring-node": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
@@ -122,6 +178,40 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@aws-crypto/decrypt-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/decrypt-node/-/decrypt-node-4.0.0.tgz",
+      "integrity": "sha512-8xJ0Bjr0l4sBKpNM+zxAqfgUlcZxb/Jqj8IOTzL5IXEO301KH/qNJ1saI37Epmb0v9iKfmCou1D8pu9Y9GnuMw==",
+      "dependencies": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.1.1",
+        "readable-stream": "^3.6.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/encrypt-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/encrypt-node/-/encrypt-node-4.0.0.tgz",
+      "integrity": "sha512-p/iSjYh3u4KFet9vmlnGn2YYf+j3aTQxh5SoxpkxnzSVvH3Sc/Ul5mPu13hIatIjrpnJGH5JNdT98igtsatWxA==",
+      "dependencies": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "@types/duplexify": "^3.6.0",
+        "duplexify": "^4.1.1",
+        "readable-stream": "^3.6.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/hkdf-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/hkdf-node/-/hkdf-node-4.0.0.tgz",
+      "integrity": "sha512-FytH3TF9c0OP+vnicc4YJoxoFoLajdRzzuRchDHmh4yXk32lj/HzgXGPfj+kSyy0chkh4XVONh2/zMRmqsA/hQ==",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      }
+    },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
@@ -134,6 +224,89 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/kms-keyring": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring/-/kms-keyring-4.0.0.tgz",
+      "integrity": "sha512-05jqVPbgzZA3R5ZBZznUtc3T9SNAdaLptRU4bnwHeB5kxrhTU8vT+Mabp9vvqhdRauPkZMZvWpvTSWIyDXiYdA==",
+      "dependencies": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/kms-keyring-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/kms-keyring-node/-/kms-keyring-node-4.0.0.tgz",
+      "integrity": "sha512-O3zjC4njVEUrgRUOpFlr4vkbGX1D2XBS9tBMJeBh5VR2Rr/j0ogiEMed6iG1VaFx3ulZ/9Ozq7VxlZxyNCx0fg==",
+      "dependencies": {
+        "@aws-crypto/kms-keyring": "^4.0.0",
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-sdk/client-kms": "^3.362.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/material-management": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management/-/material-management-4.0.0.tgz",
+      "integrity": "sha512-1hVZVxIZBc47h599h6jiBkNJnPvckvk1CSDZ9Bi/aCsqVYDFza9frki7+dOsMJu5zYB0cL/H3u1MtuUZEDlsXw==",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "bn.js": "^5.1.1",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/material-management-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/material-management-node/-/material-management-node-4.0.0.tgz",
+      "integrity": "sha512-urGhjEibLj3atMeUl8RjqmADN8cvTFFhQixvjvoQItU90t4LTPCaHBm+f52QHNhAmGEzBcKFcNBeItNTsed/Cg==",
+      "dependencies": {
+        "@aws-crypto/hkdf-node": "^4.0.0",
+        "@aws-crypto/material-management": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/raw-aes-keyring-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-aes-keyring-node/-/raw-aes-keyring-node-4.0.0.tgz",
+      "integrity": "sha512-ioXTDkEkVldm8Hmq8o1oWWdAlNz9OHiz7lMaWcAtDBJ+FDuf4pwmgX4sZyYyfs2JHhNDy9gq+L4xPp/oVIoNBw==",
+      "dependencies": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/raw-keyring": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/raw-keyring": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-keyring/-/raw-keyring-4.0.0.tgz",
+      "integrity": "sha512-Iw+WxKWM4YWAfL5xAB8wNXoCIRJr3ohH1OaGUNP5bKTR2IxDB9ALsRxdI9f61DIwWFsHAgsjIH2qecbW4RDC3Q==",
+      "dependencies": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "@aws-crypto/serialize": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/raw-rsa-keyring-node": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/raw-rsa-keyring-node/-/raw-rsa-keyring-node-4.0.0.tgz",
+      "integrity": "sha512-o1wCF8gRStr3tIMYeu46u+gYPexvNQ+JDaLzGqe9nH0dRXADDG9w5NSdx0kVmFAMvLUgJJyULcwKU2e7o4Ucpg==",
+      "dependencies": {
+        "@aws-crypto/material-management-node": "^4.0.0",
+        "@aws-crypto/raw-keyring": "^4.0.0",
+        "tslib": "^2.2.0"
+      }
+    },
+    "node_modules/@aws-crypto/serialize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/serialize/-/serialize-4.0.0.tgz",
+      "integrity": "sha512-bi3h2KA+vktnWDG2q/J7Pjgg0MsSgsytH4ZfDztj9KgKRIp9Jq0z8KcIpNK47osNG4MxOjjgqXCZsxp1bnIwjQ==",
+      "dependencies": {
+        "@aws-crypto/material-management": "^4.0.0",
+        "asn1.js": "^5.3.0",
+        "bn.js": "^5.1.1",
+        "tslib": "^2.2.0"
+      }
     },
     "node_modules/@aws-crypto/sha1-browser": {
       "version": "3.0.0",
@@ -279,125 +452,1893 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.490.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.490.0.tgz",
-      "integrity": "sha512-bU6BulAlYuRXD/rUPMvzE/hah/szww8kifdpBrB1yEJYO45TFQiJebo1n4Y7qjqe/cMi4aOeTVBQDt8E3QlYZw==",
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.574.0.tgz",
+      "integrity": "sha512-393wAq4qbMF4nBIav2FXkZF+X/6+TZrLBJrIlIiH1TrVAZkaQWzsqBjDRjYZISawOZ0Cuklm12CotIU/xNUaTQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.574.0",
+        "@aws-sdk/client-sts": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "@smithy/util-waiter": "^2.2.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.572.0.tgz",
+      "integrity": "sha512-S+xhScao5MD79AkrcHmFpEDk+CgoiuB/31WFcTcnrTio5TOUONAaT0QyscOIwRp7BZ7Aez7TBM+loTteJ+TQvg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.574.0.tgz",
+      "integrity": "sha512-WNDSG9nipap/L1gGDkCQvU2u413HmVxMJKr41lBCibioz42Z4i6XkCr1etYwIjuVfGF6QPrsEsYLqRwlAC/BQg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/core": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.572.0.tgz",
+      "integrity": "sha512-DBmf94qfN0dfaLl5EnNcq6TakWfOtVXYifHoTbX+VBwESj3rlY4W+W4mAnvBgAqDjlLFy7bBljmx+vnjnV73lg==",
+      "dependencies": {
+        "@smithy/core": "^1.4.2",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.568.0.tgz",
+      "integrity": "sha512-MVTQoZwPnP1Ev5A7LG+KzeU6sCB8BcGkZeDT1z1V5Wt7GPq0MgFQTSSjhImnB9jqRSZkl1079Bt3PbO6lfIS8g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.572.0.tgz",
+      "integrity": "sha512-anlYZnpmVkfp9Gan+LcEkQvmRf/m0KcbR11th8sBEyI5lxMaHKXhnAtC/hEGT7e3L6rgNOrFYTPuSvllITD/Pg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-http": "3.568.0",
+        "@aws-sdk/credential-provider-ini": "3.572.0",
+        "@aws-sdk/credential-provider-process": "3.572.0",
+        "@aws-sdk/credential-provider-sso": "3.572.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+      "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.490.0",
-        "@aws-sdk/core": "3.490.0",
-        "@aws-sdk/credential-provider-node": "3.490.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.489.0",
-        "@aws-sdk/middleware-host-header": "3.489.0",
-        "@aws-sdk/middleware-logger": "3.489.0",
-        "@aws-sdk/middleware-recursion-detection": "3.489.0",
-        "@aws-sdk/middleware-user-agent": "3.489.0",
-        "@aws-sdk/region-config-resolver": "3.489.0",
-        "@aws-sdk/types": "3.489.0",
-        "@aws-sdk/util-endpoints": "3.489.0",
-        "@aws-sdk/util-user-agent-browser": "3.489.0",
-        "@aws-sdk/util-user-agent-node": "3.489.0",
-        "@smithy/config-resolver": "^2.0.23",
-        "@smithy/core": "^1.2.2",
-        "@smithy/fetch-http-handler": "^2.3.2",
-        "@smithy/hash-node": "^2.0.18",
-        "@smithy/invalid-dependency": "^2.0.16",
-        "@smithy/middleware-content-length": "^2.0.18",
-        "@smithy/middleware-endpoint": "^2.3.0",
-        "@smithy/middleware-retry": "^2.0.26",
-        "@smithy/middleware-serde": "^2.0.16",
-        "@smithy/middleware-stack": "^2.0.10",
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/node-http-handler": "^2.2.2",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
-        "@smithy/url-parser": "^2.0.16",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-body-length-browser": "^2.0.1",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.24",
-        "@smithy/util-defaults-mode-node": "^2.0.32",
-        "@smithy/util-endpoints": "^1.0.8",
-        "@smithy/util-middleware": "^2.0.9",
-        "@smithy/util-retry": "^2.0.9",
-        "@smithy/util-utf8": "^2.0.2",
-        "@smithy/util-waiter": "^2.0.16",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@aws-sdk/client-sts": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sts": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+      "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
       "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.572.0.tgz",
+      "integrity": "sha512-05KzbAp77fEiQXqMeodXeMbT83FOqSyBrfSEMz6U8uBXeJCy8zPUjN3acqcbG55/HNJHUvg1cftqzy+fUz71gA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-process": "3.572.0",
+        "@aws-sdk/credential-provider-sso": "3.572.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "3.572.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.572.0.tgz",
+      "integrity": "sha512-hXcOytf0BadSm/MMy7MV8mmY0+Jv3mkavsHNBx0R82hw5ollD0I3JyOAaCtdUpztF0I72F8K+q8SpJQZ+EwArw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.572.0.tgz",
+      "integrity": "sha512-iIlnpJiDXFp3XC4hJNSiNurnU24mr3iLB3HoNa9efr944bo6XBl9FQdk3NssIkqzSmgyoB2CEUx/daBHz4XSow==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.572.0",
+        "@aws-sdk/token-providers": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+      "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sts": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+      "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.572.0.tgz",
+      "integrity": "sha512-IkSu8p32tQZhKqwmfLZLGfYwNhsS/HUQBLnDMHJlr9VifmDqlTurcr+DwMCaMimuFhcLeb45vqTymKf/ro/OBw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "3.572.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.568.0.tgz",
+      "integrity": "sha512-ZJSmTmoIdg6WqAULjYzaJ3XcbgBzVy36lir6Y0UBMRGaxDgos1AARuX6EcYzXOl+ksLvxt/xMQ+3aYh1LWfKSw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.567.0.tgz",
+      "integrity": "sha512-zQHHj2N3in9duKghH7AuRNrOMLnKhW6lnmb7dznou068DJtDr76w475sHp2TF0XELsOGENbbBsOlN/S5QBFBVQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.568.0.tgz",
+      "integrity": "sha512-BinH72RG7K3DHHC1/tCulocFv+ZlQ9SrPF9zYT0T1OT95JXuHhB7fH8gEABrc6DAtOdJJh2fgxQjPy5tzPtsrA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.567.0.tgz",
+      "integrity": "sha512-rFk3QhdT4IL6O/UWHmNdjJiURutBCy+ogGqaNHf/RELxgXH3KmYorLwCe0eFb5hq8f6vr3zl4/iH7YtsUOuo1w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.572.0.tgz",
+      "integrity": "sha512-R4bBbLp1ywtF1kJoOX1juDMztKPWeQHNj6XuTvtruFDn1RdfnBlbM3+9rguRfH5s4V+xfl8SSWchnyo2cI00xg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.572.0.tgz",
+      "integrity": "sha512-xkZMIxek44F4YW5r9otD1O5Y/kDkgAb6JNJePkP1qPVojrkCmin3OFYAOZgGm+T4DZAQ5rWhpaqTAWmnRumYfw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.572.0.tgz",
+      "integrity": "sha512-AIEC7ItIWBqkJLtqcSd0HG8tvdh3zVwqnKPHNrcfFay0Xonqx3p/qTCDwGosh5CM5hDGzyOSRA5PkacEDBTz9w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.567.0.tgz",
+      "integrity": "sha512-cqP0uXtZ7m7hRysf3fRyJwcY1jCgQTpJy7BHB5VpsE7DXlXHD5+Ur5L42CY7UrRPrB6lc6YGFqaAOs5ghMcLyA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.568.0.tgz",
+      "integrity": "sha512-NVoZoLnKF+eXPBvXg+KqixgJkPSrerR6Gqmbjwqbv14Ini+0KNKB0/MXas1mDGvvEgtNkHI/Cb9zlJ3KXpti2A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-kms": {
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.574.0.tgz",
+      "integrity": "sha512-uTxZQD7iM1RsBSXweJDHebBXbYDhdj7DBpnqk0bqMHpY3HGPQlyhM3yYKmp3d//kbqFFvd3/gcCXRTCtahsvhg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.574.0",
+        "@aws-sdk/client-sts": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/client-sso": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.572.0.tgz",
+      "integrity": "sha512-S+xhScao5MD79AkrcHmFpEDk+CgoiuB/31WFcTcnrTio5TOUONAaT0QyscOIwRp7BZ7Aez7TBM+loTteJ+TQvg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/client-sts": {
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.574.0.tgz",
+      "integrity": "sha512-WNDSG9nipap/L1gGDkCQvU2u413HmVxMJKr41lBCibioz42Z4i6XkCr1etYwIjuVfGF6QPrsEsYLqRwlAC/BQg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/core": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.572.0.tgz",
+      "integrity": "sha512-DBmf94qfN0dfaLl5EnNcq6TakWfOtVXYifHoTbX+VBwESj3rlY4W+W4mAnvBgAqDjlLFy7bBljmx+vnjnV73lg==",
+      "dependencies": {
+        "@smithy/core": "^1.4.2",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.568.0.tgz",
+      "integrity": "sha512-MVTQoZwPnP1Ev5A7LG+KzeU6sCB8BcGkZeDT1z1V5Wt7GPq0MgFQTSSjhImnB9jqRSZkl1079Bt3PbO6lfIS8g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.572.0.tgz",
+      "integrity": "sha512-anlYZnpmVkfp9Gan+LcEkQvmRf/m0KcbR11th8sBEyI5lxMaHKXhnAtC/hEGT7e3L6rgNOrFYTPuSvllITD/Pg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-http": "3.568.0",
+        "@aws-sdk/credential-provider-ini": "3.572.0",
+        "@aws-sdk/credential-provider-process": "3.572.0",
+        "@aws-sdk/credential-provider-sso": "3.572.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+      "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sts": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+      "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.572.0.tgz",
+      "integrity": "sha512-05KzbAp77fEiQXqMeodXeMbT83FOqSyBrfSEMz6U8uBXeJCy8zPUjN3acqcbG55/HNJHUvg1cftqzy+fUz71gA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-process": "3.572.0",
+        "@aws-sdk/credential-provider-sso": "3.572.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "3.572.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.572.0.tgz",
+      "integrity": "sha512-hXcOytf0BadSm/MMy7MV8mmY0+Jv3mkavsHNBx0R82hw5ollD0I3JyOAaCtdUpztF0I72F8K+q8SpJQZ+EwArw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.572.0.tgz",
+      "integrity": "sha512-iIlnpJiDXFp3XC4hJNSiNurnU24mr3iLB3HoNa9efr944bo6XBl9FQdk3NssIkqzSmgyoB2CEUx/daBHz4XSow==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.572.0",
+        "@aws-sdk/token-providers": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+      "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sts": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+      "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.572.0.tgz",
+      "integrity": "sha512-IkSu8p32tQZhKqwmfLZLGfYwNhsS/HUQBLnDMHJlr9VifmDqlTurcr+DwMCaMimuFhcLeb45vqTymKf/ro/OBw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "3.572.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.568.0.tgz",
+      "integrity": "sha512-ZJSmTmoIdg6WqAULjYzaJ3XcbgBzVy36lir6Y0UBMRGaxDgos1AARuX6EcYzXOl+ksLvxt/xMQ+3aYh1LWfKSw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.567.0.tgz",
+      "integrity": "sha512-zQHHj2N3in9duKghH7AuRNrOMLnKhW6lnmb7dznou068DJtDr76w475sHp2TF0XELsOGENbbBsOlN/S5QBFBVQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.568.0.tgz",
+      "integrity": "sha512-BinH72RG7K3DHHC1/tCulocFv+ZlQ9SrPF9zYT0T1OT95JXuHhB7fH8gEABrc6DAtOdJJh2fgxQjPy5tzPtsrA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.567.0.tgz",
+      "integrity": "sha512-rFk3QhdT4IL6O/UWHmNdjJiURutBCy+ogGqaNHf/RELxgXH3KmYorLwCe0eFb5hq8f6vr3zl4/iH7YtsUOuo1w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.572.0.tgz",
+      "integrity": "sha512-R4bBbLp1ywtF1kJoOX1juDMztKPWeQHNj6XuTvtruFDn1RdfnBlbM3+9rguRfH5s4V+xfl8SSWchnyo2cI00xg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.572.0.tgz",
+      "integrity": "sha512-xkZMIxek44F4YW5r9otD1O5Y/kDkgAb6JNJePkP1qPVojrkCmin3OFYAOZgGm+T4DZAQ5rWhpaqTAWmnRumYfw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.572.0.tgz",
+      "integrity": "sha512-AIEC7ItIWBqkJLtqcSd0HG8tvdh3zVwqnKPHNrcfFay0Xonqx3p/qTCDwGosh5CM5hDGzyOSRA5PkacEDBTz9w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.567.0.tgz",
+      "integrity": "sha512-cqP0uXtZ7m7hRysf3fRyJwcY1jCgQTpJy7BHB5VpsE7DXlXHD5+Ur5L42CY7UrRPrB6lc6YGFqaAOs5ghMcLyA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.568.0.tgz",
+      "integrity": "sha512-NVoZoLnKF+eXPBvXg+KqixgJkPSrerR6Gqmbjwqbv14Ini+0KNKB0/MXas1mDGvvEgtNkHI/Cb9zlJ3KXpti2A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-qbusiness": {
-      "version": "3.490.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-qbusiness/-/client-qbusiness-3.490.0.tgz",
-      "integrity": "sha512-La/wEn+qGRzAMrZG3TSAo+mQnzK0P9XnAF/OlFpGFLISlJgAQpokoHCqYCyTzSvGBIXut/Ll9Ts9n1j3TdZ6hQ==",
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-qbusiness/-/client-qbusiness-3.574.0.tgz",
+      "integrity": "sha512-MunUA9+WVM+fwbXOPzXuNaOjo3Gr41eLUj7d4Bpxy+nUAENxG5eCqSAA1LjAOpSNcUp/0NsmhrWzCOFPyXr4GQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
         "@aws-crypto/sha256-js": "3.0.0",
-        "@aws-sdk/client-sts": "3.490.0",
-        "@aws-sdk/core": "3.490.0",
-        "@aws-sdk/credential-provider-node": "3.490.0",
-        "@aws-sdk/middleware-host-header": "3.489.0",
-        "@aws-sdk/middleware-logger": "3.489.0",
-        "@aws-sdk/middleware-recursion-detection": "3.489.0",
-        "@aws-sdk/middleware-signing": "3.489.0",
-        "@aws-sdk/middleware-user-agent": "3.489.0",
-        "@aws-sdk/region-config-resolver": "3.489.0",
-        "@aws-sdk/types": "3.489.0",
-        "@aws-sdk/util-endpoints": "3.489.0",
-        "@aws-sdk/util-user-agent-browser": "3.489.0",
-        "@aws-sdk/util-user-agent-node": "3.489.0",
-        "@smithy/config-resolver": "^2.0.23",
-        "@smithy/core": "^1.2.2",
-        "@smithy/fetch-http-handler": "^2.3.2",
-        "@smithy/hash-node": "^2.0.18",
-        "@smithy/invalid-dependency": "^2.0.16",
-        "@smithy/middleware-content-length": "^2.0.18",
-        "@smithy/middleware-endpoint": "^2.3.0",
-        "@smithy/middleware-retry": "^2.0.26",
-        "@smithy/middleware-serde": "^2.0.16",
-        "@smithy/middleware-stack": "^2.0.10",
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/node-http-handler": "^2.2.2",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
-        "@smithy/url-parser": "^2.0.16",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-body-length-browser": "^2.0.1",
-        "@smithy/util-body-length-node": "^2.1.0",
-        "@smithy/util-defaults-mode-browser": "^2.0.24",
-        "@smithy/util-defaults-mode-node": "^2.0.32",
-        "@smithy/util-endpoints": "^1.0.8",
-        "@smithy/util-retry": "^2.0.9",
-        "@smithy/util-utf8": "^2.0.2",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@aws-sdk/client-sso-oidc": "3.574.0",
+        "@aws-sdk/client-sts": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/eventstream-handler-node": "3.568.0",
+        "@aws-sdk/middleware-eventstream": "3.569.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/eventstream-serde-browser": "^2.2.0",
+        "@smithy/eventstream-serde-config-resolver": "^2.2.0",
+        "@smithy/eventstream-serde-node": "^2.2.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-qbusiness/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/client-sso": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.572.0.tgz",
+      "integrity": "sha512-S+xhScao5MD79AkrcHmFpEDk+CgoiuB/31WFcTcnrTio5TOUONAaT0QyscOIwRp7BZ7Aez7TBM+loTteJ+TQvg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/client-sts": {
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.574.0.tgz",
+      "integrity": "sha512-WNDSG9nipap/L1gGDkCQvU2u413HmVxMJKr41lBCibioz42Z4i6XkCr1etYwIjuVfGF6QPrsEsYLqRwlAC/BQg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/core": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.572.0.tgz",
+      "integrity": "sha512-DBmf94qfN0dfaLl5EnNcq6TakWfOtVXYifHoTbX+VBwESj3rlY4W+W4mAnvBgAqDjlLFy7bBljmx+vnjnV73lg==",
+      "dependencies": {
+        "@smithy/core": "^1.4.2",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.568.0.tgz",
+      "integrity": "sha512-MVTQoZwPnP1Ev5A7LG+KzeU6sCB8BcGkZeDT1z1V5Wt7GPq0MgFQTSSjhImnB9jqRSZkl1079Bt3PbO6lfIS8g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.572.0.tgz",
+      "integrity": "sha512-anlYZnpmVkfp9Gan+LcEkQvmRf/m0KcbR11th8sBEyI5lxMaHKXhnAtC/hEGT7e3L6rgNOrFYTPuSvllITD/Pg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-http": "3.568.0",
+        "@aws-sdk/credential-provider-ini": "3.572.0",
+        "@aws-sdk/credential-provider-process": "3.572.0",
+        "@aws-sdk/credential-provider-sso": "3.572.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+      "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sts": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+      "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.572.0.tgz",
+      "integrity": "sha512-05KzbAp77fEiQXqMeodXeMbT83FOqSyBrfSEMz6U8uBXeJCy8zPUjN3acqcbG55/HNJHUvg1cftqzy+fUz71gA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-process": "3.572.0",
+        "@aws-sdk/credential-provider-sso": "3.572.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "3.572.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.572.0.tgz",
+      "integrity": "sha512-hXcOytf0BadSm/MMy7MV8mmY0+Jv3mkavsHNBx0R82hw5ollD0I3JyOAaCtdUpztF0I72F8K+q8SpJQZ+EwArw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.572.0.tgz",
+      "integrity": "sha512-iIlnpJiDXFp3XC4hJNSiNurnU24mr3iLB3HoNa9efr944bo6XBl9FQdk3NssIkqzSmgyoB2CEUx/daBHz4XSow==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.572.0",
+        "@aws-sdk/token-providers": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+      "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sts": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+      "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.572.0.tgz",
+      "integrity": "sha512-IkSu8p32tQZhKqwmfLZLGfYwNhsS/HUQBLnDMHJlr9VifmDqlTurcr+DwMCaMimuFhcLeb45vqTymKf/ro/OBw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "3.572.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.568.0.tgz",
+      "integrity": "sha512-ZJSmTmoIdg6WqAULjYzaJ3XcbgBzVy36lir6Y0UBMRGaxDgos1AARuX6EcYzXOl+ksLvxt/xMQ+3aYh1LWfKSw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.567.0.tgz",
+      "integrity": "sha512-zQHHj2N3in9duKghH7AuRNrOMLnKhW6lnmb7dznou068DJtDr76w475sHp2TF0XELsOGENbbBsOlN/S5QBFBVQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.568.0.tgz",
+      "integrity": "sha512-BinH72RG7K3DHHC1/tCulocFv+ZlQ9SrPF9zYT0T1OT95JXuHhB7fH8gEABrc6DAtOdJJh2fgxQjPy5tzPtsrA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.567.0.tgz",
+      "integrity": "sha512-rFk3QhdT4IL6O/UWHmNdjJiURutBCy+ogGqaNHf/RELxgXH3KmYorLwCe0eFb5hq8f6vr3zl4/iH7YtsUOuo1w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.572.0.tgz",
+      "integrity": "sha512-R4bBbLp1ywtF1kJoOX1juDMztKPWeQHNj6XuTvtruFDn1RdfnBlbM3+9rguRfH5s4V+xfl8SSWchnyo2cI00xg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.572.0.tgz",
+      "integrity": "sha512-xkZMIxek44F4YW5r9otD1O5Y/kDkgAb6JNJePkP1qPVojrkCmin3OFYAOZgGm+T4DZAQ5rWhpaqTAWmnRumYfw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.572.0.tgz",
+      "integrity": "sha512-AIEC7ItIWBqkJLtqcSd0HG8tvdh3zVwqnKPHNrcfFay0Xonqx3p/qTCDwGosh5CM5hDGzyOSRA5PkacEDBTz9w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.567.0.tgz",
+      "integrity": "sha512-cqP0uXtZ7m7hRysf3fRyJwcY1jCgQTpJy7BHB5VpsE7DXlXHD5+Ur5L42CY7UrRPrB6lc6YGFqaAOs5ghMcLyA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-qbusiness/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.568.0.tgz",
+      "integrity": "sha512-NVoZoLnKF+eXPBvXg+KqixgJkPSrerR6Gqmbjwqbv14Ini+0KNKB0/MXas1mDGvvEgtNkHI/Cb9zlJ3KXpti2A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-sdk/client-s3": {
@@ -515,6 +2456,632 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.574.0.tgz",
+      "integrity": "sha512-WcR8AnFhx7bqhYwfSl3OrF0Pu0LfHGgSOnmmORHqRF7ykguE09M/WUlCCjTGmZjJZ1we3uF5Xg8Jg12eiD+bmw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/client-sso": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.572.0.tgz",
+      "integrity": "sha512-S+xhScao5MD79AkrcHmFpEDk+CgoiuB/31WFcTcnrTio5TOUONAaT0QyscOIwRp7BZ7Aez7TBM+loTteJ+TQvg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/client-sts": {
+      "version": "3.574.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.574.0.tgz",
+      "integrity": "sha512-WNDSG9nipap/L1gGDkCQvU2u413HmVxMJKr41lBCibioz42Z4i6XkCr1etYwIjuVfGF6QPrsEsYLqRwlAC/BQg==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.574.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/core": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.572.0.tgz",
+      "integrity": "sha512-DBmf94qfN0dfaLl5EnNcq6TakWfOtVXYifHoTbX+VBwESj3rlY4W+W4mAnvBgAqDjlLFy7bBljmx+vnjnV73lg==",
+      "dependencies": {
+        "@smithy/core": "^1.4.2",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/signature-v4": "^2.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.568.0.tgz",
+      "integrity": "sha512-MVTQoZwPnP1Ev5A7LG+KzeU6sCB8BcGkZeDT1z1V5Wt7GPq0MgFQTSSjhImnB9jqRSZkl1079Bt3PbO6lfIS8g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.572.0.tgz",
+      "integrity": "sha512-anlYZnpmVkfp9Gan+LcEkQvmRf/m0KcbR11th8sBEyI5lxMaHKXhnAtC/hEGT7e3L6rgNOrFYTPuSvllITD/Pg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-http": "3.568.0",
+        "@aws-sdk/credential-provider-ini": "3.572.0",
+        "@aws-sdk/credential-provider-process": "3.572.0",
+        "@aws-sdk/credential-provider-sso": "3.572.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+      "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/client-sts": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+      "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-node/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.572.0.tgz",
+      "integrity": "sha512-05KzbAp77fEiQXqMeodXeMbT83FOqSyBrfSEMz6U8uBXeJCy8zPUjN3acqcbG55/HNJHUvg1cftqzy+fUz71gA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.568.0",
+        "@aws-sdk/credential-provider-process": "3.572.0",
+        "@aws-sdk/credential-provider-sso": "3.572.0",
+        "@aws-sdk/credential-provider-web-identity": "3.568.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "3.572.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.572.0.tgz",
+      "integrity": "sha512-hXcOytf0BadSm/MMy7MV8mmY0+Jv3mkavsHNBx0R82hw5ollD0I3JyOAaCtdUpztF0I72F8K+q8SpJQZ+EwArw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.572.0.tgz",
+      "integrity": "sha512-iIlnpJiDXFp3XC4hJNSiNurnU24mr3iLB3HoNa9efr944bo6XBl9FQdk3NssIkqzSmgyoB2CEUx/daBHz4XSow==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.572.0",
+        "@aws-sdk/token-providers": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.572.0.tgz",
+      "integrity": "sha512-S6C/S6xYesDakEuzYvlY1DMMKLtKQxdbbygq3hfeG2R0jUt9KpRLsQXK8qrBuVCKa3WcnjN/30hp4g/iUWFU/w==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/client-sts": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.572.0.tgz",
+      "integrity": "sha512-jCQuH2qkbWoSY4wckLSfzf3OPh7zc7ZckEbIGGVUQar/JVff6EIbpQ+uNG29DDEOpdPPd8rrJsVuUlA/nvJdXA==",
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sso-oidc": "3.572.0",
+        "@aws-sdk/core": "3.572.0",
+        "@aws-sdk/credential-provider-node": "3.572.0",
+        "@aws-sdk/middleware-host-header": "3.567.0",
+        "@aws-sdk/middleware-logger": "3.568.0",
+        "@aws-sdk/middleware-recursion-detection": "3.567.0",
+        "@aws-sdk/middleware-user-agent": "3.572.0",
+        "@aws-sdk/region-config-resolver": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@aws-sdk/util-user-agent-browser": "3.567.0",
+        "@aws-sdk/util-user-agent-node": "3.568.0",
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/core": "^1.4.2",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/hash-node": "^2.2.0",
+        "@smithy/invalid-dependency": "^2.2.0",
+        "@smithy/middleware-content-length": "^2.2.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-body-length-browser": "^2.2.0",
+        "@smithy/util-body-length-node": "^2.3.0",
+        "@smithy/util-defaults-mode-browser": "^2.2.1",
+        "@smithy/util-defaults-mode-node": "^2.3.1",
+        "@smithy/util-endpoints": "^1.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.572.0.tgz",
+      "integrity": "sha512-IkSu8p32tQZhKqwmfLZLGfYwNhsS/HUQBLnDMHJlr9VifmDqlTurcr+DwMCaMimuFhcLeb45vqTymKf/ro/OBw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sso-oidc": "3.572.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.568.0.tgz",
+      "integrity": "sha512-ZJSmTmoIdg6WqAULjYzaJ3XcbgBzVy36lir6Y0UBMRGaxDgos1AARuX6EcYzXOl+ksLvxt/xMQ+3aYh1LWfKSw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-sts": "^3.568.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.567.0.tgz",
+      "integrity": "sha512-zQHHj2N3in9duKghH7AuRNrOMLnKhW6lnmb7dznou068DJtDr76w475sHp2TF0XELsOGENbbBsOlN/S5QBFBVQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.568.0.tgz",
+      "integrity": "sha512-BinH72RG7K3DHHC1/tCulocFv+ZlQ9SrPF9zYT0T1OT95JXuHhB7fH8gEABrc6DAtOdJJh2fgxQjPy5tzPtsrA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.567.0.tgz",
+      "integrity": "sha512-rFk3QhdT4IL6O/UWHmNdjJiURutBCy+ogGqaNHf/RELxgXH3KmYorLwCe0eFb5hq8f6vr3zl4/iH7YtsUOuo1w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.572.0.tgz",
+      "integrity": "sha512-R4bBbLp1ywtF1kJoOX1juDMztKPWeQHNj6XuTvtruFDn1RdfnBlbM3+9rguRfH5s4V+xfl8SSWchnyo2cI00xg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@aws-sdk/util-endpoints": "3.572.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.572.0.tgz",
+      "integrity": "sha512-xkZMIxek44F4YW5r9otD1O5Y/kDkgAb6JNJePkP1qPVojrkCmin3OFYAOZgGm+T4DZAQ5rWhpaqTAWmnRumYfw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.572.0.tgz",
+      "integrity": "sha512-AIEC7ItIWBqkJLtqcSd0HG8tvdh3zVwqnKPHNrcfFay0Xonqx3p/qTCDwGosh5CM5hDGzyOSRA5PkacEDBTz9w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-endpoints": "^1.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.567.0.tgz",
+      "integrity": "sha512-cqP0uXtZ7m7hRysf3fRyJwcY1jCgQTpJy7BHB5VpsE7DXlXHD5+Ur5L42CY7UrRPrB6lc6YGFqaAOs5ghMcLyA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/types": "^2.12.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.568.0.tgz",
+      "integrity": "sha512-NVoZoLnKF+eXPBvXg+KqixgJkPSrerR6Gqmbjwqbv14Ini+0KNKB0/MXas1mDGvvEgtNkHI/Cb9zlJ3KXpti2A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@aws-sdk/client-sts": {
       "version": "3.490.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
@@ -593,6 +3160,37 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.568.0.tgz",
+      "integrity": "sha512-gL0NlyI2eW17hnCrh45hZV+qjtBquB+Bckiip9R6DIVRKqYcoILyiFhuOgf2bXeF23gVh6j18pvUvIoTaFWs5w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
@@ -683,16 +3281,41 @@
       }
     },
     "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.465.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.465.0.tgz",
-      "integrity": "sha512-0cuotk23hVSrqxHkJ3TTWC9MVMRgwlUvCatyegJEauJnk8kpLSGXE5KVdExlUBwShGNlj7ac29okZ9m17iTi5Q==",
-      "peer": true,
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.572.0.tgz",
+      "integrity": "sha512-CzuRWMj/xtN9p9eP915nlPmlyniTzke732Ow/M60++gGgB3W+RtZyFftw3TEx+NzNhd1tH54dEcGiWdiNaBz3Q==",
       "dependencies": {
         "mnemonist": "0.38.3",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.568.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.568.0.tgz",
+      "integrity": "sha512-adbab6GFdvUSLq7kp2b+G5iArIpqKTbUo2Sw9f9HZtCs0cK+KiFQTwyphAIEQNISo5OaZXvds3EE0VUbCSfMnA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
@@ -730,20 +3353,57 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.489.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.489.0.tgz",
-      "integrity": "sha512-R1DHQj5SdcYLnAkZ3X2cdERKmG+h+KejwkyNtzPNwmfOcsCrOVnRLtaXv4T9q9wJD6+SjN1zeQBQGyILI0CiQQ==",
-      "peer": true,
+      "version": "3.572.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.572.0.tgz",
+      "integrity": "sha512-kMgeCeY3V4wmUddzo/PWtkbHhppKHzc0KW9ZUIKKAEujzsSSETyj63ntAZB1u7Wa9ejcCVhVriUciD9DKXR8nQ==",
       "dependencies": {
-        "@aws-sdk/endpoint-cache": "3.465.0",
-        "@aws-sdk/types": "3.489.0",
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@aws-sdk/endpoint-cache": "3.572.0",
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.569.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.569.0.tgz",
+      "integrity": "sha512-5wU94+venbuEIdPDIuzBKu7NQABJ+H7Ud+XbOPKWHv1lTZrIkPT9rZ/r2R5NP0mNeYHlbALOwum79tVNCDw+Pw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.567.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream/node_modules/@aws-sdk/types": {
+      "version": "3.567.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.567.0.tgz",
+      "integrity": "sha512-JBznu45cdgQb8+T/Zab7WpBmfEAh77gsk99xuF4biIb2Sw1mdseONdoGDjEJX57a25TzIv/WUJ2oABWumckz1A==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
@@ -1091,85 +3751,85 @@
       }
     },
     "node_modules/@azure/abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
-      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
       "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.5.0.tgz",
-      "integrity": "sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.7.2.tgz",
+      "integrity": "sha512-Igm/S3fDYmnMq1uKS38Ae1/m37B3zigdlZw+kocwEhh5GjyKjPrXKO2J6rzpC1wAxrNil/jX9BJRqBshyjnF3g==",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-util": "^1.1.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.7.3.tgz",
-      "integrity": "sha512-kleJ1iUTxcO32Y06dH9Pfi9K4U+Tlb111WXEnbt7R/ne+NLRwppZiTGJuTD5VVoxTMK5NTbEtm5t2vcdNCFe2g==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.9.2.tgz",
+      "integrity": "sha512-kRdry/rav3fUKHl/aDLd/pDLcB+4pOFwPPTVEExuMyaI5r+JBbMWqRbCY1pn5BniDaU3lRxO9eaQ1AmSMehl/w==",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.9.1",
         "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.0.0",
+        "@azure/core-util": "^1.6.1",
         "@azure/logger": "^1.0.0",
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.13.0.tgz",
-      "integrity": "sha512-a62aP/wppgmnfIkJLfcB4ssPBcH94WzrzPVJ3tlJt050zX4lfmtnvy95D3igDo3f31StO+9BgPrzvkj4aOxnoA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.16.0.tgz",
+      "integrity": "sha512-CeuTvsXxCUmEuxH5g/aceuSl6w2EugvNHKAtKKVdiX915EjJJxAwfzNNWZreNnbxHZ2fi0zaM6wwS23x2JVqSQ==",
       "dependencies": {
-        "@azure/abort-controller": "^1.1.0",
+        "@azure/abort-controller": "^2.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/core-tracing": "^1.0.1",
-        "@azure/core-util": "^1.3.0",
+        "@azure/core-util": "^1.9.0",
         "@azure/logger": "^1.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "tslib": "^2.2.0"
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-tracing": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.1.tgz",
-      "integrity": "sha512-I5CGMoLtX+pI17ZdiFJZgxMJApsK6jjfm85hpgp3oazCdq5Wxgh4wMr7ge/TTWW1B5WBuvIOI1fMU/FrOAMKrw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.1.2.tgz",
+      "integrity": "sha512-dawW9ifvWAWmUm9/h+/UQ2jrdvjCJ7VJEuCJ6XVNudzcOwm53BFZH4Q845vjfgoUAM8ZxokvVNxNxAITc502YA==",
       "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/core-util": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.6.1.tgz",
-      "integrity": "sha512-h5taHeySlsV9qxuK64KZxy4iln1BtMYlNt5jbuEFN3UFSAd1EwKg/Gjl5a6tZ/W8t6li3xPnutOx7zbDyXnPmQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.9.0.tgz",
+      "integrity": "sha512-AfalUQ1ZppaKuxPPMsFEUdX6GZPB3d9paR9d/TTL7Ow2De8cJaC7ibi7kWVlFAVPCYo31OcnGymc0R89DX8Oaw==",
       "dependencies": {
-        "@azure/abort-controller": "^1.0.0",
-        "tslib": "^2.2.0"
+        "@azure/abort-controller": "^2.0.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/identity": {
@@ -1193,6 +3853,17 @@
         "stoppable": "^1.1.0",
         "tslib": "^2.2.0",
         "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+      "dependencies": {
+        "tslib": "^2.2.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1245,14 +3916,14 @@
       }
     },
     "node_modules/@azure/logger": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.4.tgz",
-      "integrity": "sha512-ustrPY8MryhloQj7OWGe+HrYx+aoiOxzbXTtgblbV3xwCqpzUK36phH3XNHQKj3EPonyFUuDTfR3qFhTEAuZEg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.1.2.tgz",
+      "integrity": "sha512-l170uE7bsKpIU6B/giRc9i4NI0Mj+tANMMMxf7Zi/5cKzEqPayP7+X1WPrG7e+91JgY8N+7K7nF2WOi7iVhXvg==",
       "dependencies": {
-        "tslib": "^2.2.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/ms-rest-js": {
@@ -1284,10 +3955,9 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "2.38.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.38.3.tgz",
-      "integrity": "sha512-2WuLFnWWPR1IdvhhysT18cBbkXx1z0YIchVss5AwVA95g7CU5CpT3d+5BcgVGNXDXbUU7/5p0xYHV99V5z8C/A==",
-      "deprecated": "A newer major version of this library is available. Please upgrade to the latest available version.",
+      "version": "2.38.4",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.38.4.tgz",
+      "integrity": "sha512-d1qSanWO9fRKurrxhiyMOIj2jMoGw+2pHb51l2PXNwref7xQO+UeOP2q++5xfHQoUmgTtNuERhitynHla+dvhQ==",
       "dependencies": {
         "@azure/msal-common": "13.3.1"
       },
@@ -2714,12 +5384,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.0.16.tgz",
-      "integrity": "sha512-4foO7738k8kM9flMHu3VLabqu7nPgvIj8TB909S0CnKx0YZz/dcDH3pZ/4JHdatfxlZdKF1JWOYCw9+v3HVVsw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2743,125 +5413,125 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "2.0.23",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.0.23.tgz",
-      "integrity": "sha512-XakUqgtP2YY8Mi+Nlif5BiqJgWdvfxJafSpOSQeCOMizu+PUhE4fBQSy6xFcR+eInrwVadaABNxoJyGUMn15ew==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.2.0.tgz",
+      "integrity": "sha512-fsiMgd8toyUba6n1WRmr+qACzXltpdDkPTAaDqc8QqPBUzO+/JKwL6bUBseHVi8tu9l+3JOK+tSf7cay+4B3LA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-config-provider": "^2.1.0",
-        "@smithy/util-middleware": "^2.0.9",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-config-provider": "^2.3.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.2.2.tgz",
-      "integrity": "sha512-uLjrskLT+mWb0emTR5QaiAIxVEU7ndpptDaVDrTwwhD+RjvHhjIiGQ3YL5jKk1a5VSDQUA2RGkXvJ6XKRcz6Dg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-2fek3I0KZHWJlRLvRTqxTEri+qV0GRHrJIoLFuBMZB4EMg4WgeBGfF0X6abnrNYpq55KJ6R4D6x4f0vLnhzinA==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.3.0",
-        "@smithy/middleware-retry": "^2.0.26",
-        "@smithy/middleware-serde": "^2.0.16",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-middleware": "^2.0.9",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.1.5.tgz",
-      "integrity": "sha512-VfvE6Wg1MUWwpTZFBnUD7zxvPhLY8jlHCzu6bCjlIYoWgXCDzZAML76IlZUEf45nib3rjehnFgg0s1rgsuN/bg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
+      "integrity": "sha512-BWB9mIukO1wjEOo1Ojgl6LrG4avcaC7T/ZP6ptmAaW4xluhSIPZhY+/PI5YKzlk+jsm+4sQZB45Bt1OfMeQa3w==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/property-provider": "^2.0.17",
-        "@smithy/types": "^2.8.0",
-        "@smithy/url-parser": "^2.0.16",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.0.16.tgz",
-      "integrity": "sha512-umYh5pdCE9GHgiMAH49zu9wXWZKNHHdKPm/lK22WYISTjqu29SepmpWNmPiBLy/yUu4HFEGJHIFrDWhbDlApaw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.2.0.tgz",
+      "integrity": "sha512-8janZoJw85nJmQZc4L8TuePp2pk1nxLgkxIR0TUjKJ5Dkj5oelB9WtiSSGXCQvNsJl0VSTvK/2ueMXxvpa9GVw==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.0.16.tgz",
-      "integrity": "sha512-W+BdiN728R57KuZOcG0GczpIOEFf8S5RP/OdVH7T3FMCy8HU2bBU0vB5xZZR5c00VRdoeWrohNv3XlHoZuGRoA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.2.0.tgz",
+      "integrity": "sha512-UaPf8jKbcP71BGiO0CdeLmlg+RhWnlN8ipsMSdwvqBFigl5nil3rHOI/5GE3tfiuX8LvY5Z9N0meuU7Rab7jWw==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.0.16",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.0.16.tgz",
-      "integrity": "sha512-8qrE4nh+Tg6m1SMFK8vlzoK+8bUFTlIhXidmmQfASMninXW3Iu0T0bI4YcIk4nLznHZdybQ0qGydIanvVZxzVg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.2.0.tgz",
+      "integrity": "sha512-RHhbTw/JW3+r8QQH7PrganjNCiuiEZmpi6fYUAetFfPLfZ6EkiA08uN3EFfcyKubXQxOwTeJRZSQmDDCdUshaA==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.0.16.tgz",
-      "integrity": "sha512-NRNQuOa6mQdFSkqzY0IV37swHWx0SEoKxFtUfdZvfv0AVQPlSw4N7E3kcRSCpnHBr1kCuWWirdDlWcjWuD81MA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.2.0.tgz",
+      "integrity": "sha512-zpQMtJVqCUMn+pCSFcl9K/RPNtQE0NuMh8sKpCdEHafhwRsjP50Oq/4kMmvxSRy6d8Jslqd8BLvDngrUtmN9iA==",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^2.0.16",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-serde-universal": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.0.16.tgz",
-      "integrity": "sha512-ZyLnGaYQMLc75j9kKEVMJ3X6bdBE9qWxhZdTXM5RIltuytxJC3FaOhawBxjE+IL1enmWSIohHGZCm/pLwEliQA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.2.0.tgz",
+      "integrity": "sha512-pvoe/vvJY0mOpuF84BEtyZoYfbehiFj8KKWk1ds2AT0mTLYFVs+7sBJZmioOFdBXKd48lfrx1vumdPdmGlCLxA==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.16",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/eventstream-codec": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.3.2.tgz",
-      "integrity": "sha512-O9R/OlnAOTsnysuSDjt0v2q6DcSvCz5cCFC/CFAWWcLyBwJDeFyGTCTszgpQTb19+Fi8uRwZE5/3ziAQBFeDMQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/querystring-builder": "^2.0.16",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-base64": "^2.0.1",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
@@ -2876,14 +5546,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.0.18.tgz",
-      "integrity": "sha512-gN2JFvAgnZCyDN9rJgcejfpK0uPPJrSortVVVVWsru9whS7eQey6+gj2eM5ln2i6rHNntIXzal1Fm9XOPuoaKA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.2.0.tgz",
+      "integrity": "sha512-zLWaC/5aWpMrHKpoDF6nqpNtBhlAYKF/7+9yMN7GpdR8CzohnWfGtMznPybnwSS8saaXBMxIGwJqR4HmRp6b3g==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.2",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2903,20 +5573,20 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.0.16.tgz",
-      "integrity": "sha512-apEHakT/kmpNo1VFHP4W/cjfeP9U0x5qvfsLJubgp7UM/gq4qYp0GbqdE7QhsjUaYvEnrftRqs7+YrtWreV0wA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.2.0.tgz",
+      "integrity": "sha512-nEDASdbKFKPXN2O6lOlTgrEEOO9NHIeO+HVvZnkqc8h5U9g3BIhWsvzFo+UcUbliMHvKNPD/zVxDrkP1Sbgp8Q==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.0.0.tgz",
-      "integrity": "sha512-z3PjFjMyZNI98JFRJi/U0nGoLWMSJlDjAW4QUX2WNZLas5C0CmVV6LJ01JI0k90l7FvpmixjWxPFmENSClQ7ug==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -2933,437 +5603,421 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.0.18.tgz",
-      "integrity": "sha512-ZJ9uKPTfxYheTKSKYB+GCvcj+izw9WGzRLhjn8n254q0jWLojUzn7Vw0l4R/Gq7Wdpf/qmk/ptD+6CCXHNVCaw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.2.0.tgz",
+      "integrity": "sha512-5bl2LG1Ah/7E5cMSC+q+h3IpVHMeOkG0yLRyQT1p2aMJkSrZG7RlXHPuAgb7EyaFeidKEnnd/fNaLLaKlHGzDQ==",
       "dependencies": {
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.3.0.tgz",
-      "integrity": "sha512-VsOAG2YQ8ykjSmKO+CIXdJBIWFo6AAvG6Iw95BakBTqk66/4BI7XyqLevoNSq/lZ6NgZv24sLmrcIN+fLDWBCg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+      "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
       "dependencies": {
-        "@smithy/middleware-serde": "^2.0.16",
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/shared-ini-file-loader": "^2.2.8",
-        "@smithy/types": "^2.8.0",
-        "@smithy/url-parser": "^2.0.16",
-        "@smithy/util-middleware": "^2.0.9",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.0.26",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.0.26.tgz",
-      "integrity": "sha512-Qzpxo0U5jfNiq9iD38U3e2bheXwvTEX4eue9xruIvEgh+UKq6dKuGqcB66oBDV7TD/mfoJi9Q/VmaiqwWbEp7A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+      "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/service-error-classification": "^2.0.9",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-middleware": "^2.0.9",
-        "@smithy/util-retry": "^2.0.9",
-        "tslib": "^2.5.0",
-        "uuid": "^8.3.2"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-retry": "^2.2.0",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@smithy/middleware-retry/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/@smithy/middleware-serde": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.0.16.tgz",
-      "integrity": "sha512-5EAd4t30pcc4M8TSSGq7q/x5IKrxfXR5+SrU4bgxNy7RPHQo2PSWBUco9C+D9Tfqp/JZvprRpK42dnupZafk2g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.0.10.tgz",
-      "integrity": "sha512-I2rbxctNq9FAPPEcuA1ntZxkTKOPQFy7YBPOaD/MLg1zCvzv21CoNxR0py6J8ZVC35l4qE4nhxB0f7TF5/+Ldw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "2.1.9",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.1.9.tgz",
-      "integrity": "sha512-tUyW/9xrRy+s7RXkmQhgYkAPMpTIF8izK4orhHjNFEKR3QZiOCbWB546Y8iB/Fpbm3O9+q0Af9rpywLKJOwtaQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.17",
-        "@smithy/shared-ini-file-loader": "^2.2.8",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.2.2.tgz",
-      "integrity": "sha512-XO58TO/Eul/IBQKFKaaBtXJi0ItEQQCT+NI4IiKHCY/4KtqaUT6y/wC1EvDqlA9cP7Dyjdj7FdPs4DyynH3u7g==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.16",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/querystring-builder": "^2.0.16",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.0.17.tgz",
-      "integrity": "sha512-+VkeZbVu7qtQ2DjI48Qwaf9fPOr3gZIwxQpuLJgRRSkWsdSvmaTCxI3gzRFKePB63Ts9r4yjn4HkxSCSkdWmcQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.0.12.tgz",
-      "integrity": "sha512-Xz4iaqLiaBfbQpB9Hgi3VcZYbP7xRDXYhd8XWChh4v94uw7qwmvlxdU5yxzfm6ACJM66phHrTbS5TVvj5uQ72w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.0.16.tgz",
-      "integrity": "sha512-Q/GsJT0C0mijXMRs7YhZLLCP5FcuC4797lYjKQkME5CZohnLC4bEhylAd2QcD3gbMKNjCw8+T2I27WKiV/wToA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.0.16.tgz",
-      "integrity": "sha512-c4ueAuL6BDYKWpkubjrQthZKoC3L5kql5O++ovekNxiexRXTlLIVlCR4q3KziOktLIw66EU9SQljPXd/oN6Okg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.0.9.tgz",
-      "integrity": "sha512-0K+8GvtwI7VkGmmInPydM2XZyBfIqLIbfR7mDQ+oPiz8mIinuHbV6sxOLdvX1Jv/myk7XTK9orgt3tuEpBu/zg==",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.5.tgz",
+      "integrity": "sha512-uBDTIBBEdAQryvHdc5W8sS5YX7RQzF683XrHePVdFmAgKiMofU15FLSM0/HU03hKTnazdNRFa0YHS7+ArwoUSQ==",
       "dependencies": {
-        "@smithy/types": "^2.8.0"
+        "@smithy/types": "^2.12.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.2.8.tgz",
-      "integrity": "sha512-E62byatbwSWrtq9RJ7xN40tqrRKDGrEL4EluyNpaIDvfvet06a/QC58oHw2FgVaEgkj0tXZPjZaKrhPfpoU0qw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.0.19.tgz",
-      "integrity": "sha512-nwc3JihdM+kcJjtORv/n7qRHN2Kfh7S2RJI2qr8pz9UcY5TD8rSCRGQ0g81HgyS3jZ5X9U/L4p014P3FonBPhg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.3.0.tgz",
+      "integrity": "sha512-ui/NlpILU+6HAQBfJX8BBsDXuKSNrjTSuOYArRblcrErwKFutjrCNb/OExfVRyj9+26F9J+ZmfWT+fKWuDrH3Q==",
       "dependencies": {
-        "@smithy/eventstream-codec": "^2.0.16",
-        "@smithy/is-array-buffer": "^2.0.0",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-middleware": "^2.0.9",
-        "@smithy/util-uri-escape": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.2",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.2.1.tgz",
-      "integrity": "sha512-SpD7FLK92XV2fon2hMotaNDa2w5VAy5/uVjP9WFmjGSgWM8pTPVkHcDl1yFs5Z8LYbij0FSz+DbCBK6i+uXXUA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+      "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.3.0",
-        "@smithy/middleware-stack": "^2.0.10",
-        "@smithy/protocol-http": "^3.0.12",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-stream": "^2.0.24",
-        "tslib": "^2.5.0"
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/types": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.8.0.tgz",
-      "integrity": "sha512-h9sz24cFgt/W1Re22OlhQKmUZkNh244ApgRsUDYinqF8R+QgcsBIX344u2j61TPshsTz3CvL6HYU1DnQdsSrHA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.0.16.tgz",
-      "integrity": "sha512-Wfz5WqAoRT91TjRy1JeLR0fXtkIXHGsMbgzKFTx7E68SrZ55TB8xoG+vm11Ru4gheFTMXjAjwAxv1jQdC+pAQA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
       "dependencies": {
-        "@smithy/querystring-parser": "^2.0.16",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.0.1.tgz",
-      "integrity": "sha512-DlI6XFYDMsIVN+GH9JtcRp3j02JEVuWIn/QOZisVzpIAprdsxGveFed0bjbMRCqmIFe8uetn5rxzNrBtIGrPIQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.0.1.tgz",
-      "integrity": "sha512-NXYp3ttgUlwkaug4bjBzJ5+yIbUbUx8VsSLuHZROQpoik+gRkIBeEG9MPVYfvPNpuXb/puqodeeUXcKFe7BLOQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+      "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.1.0.tgz",
-      "integrity": "sha512-/li0/kj/y3fQ3vyzn36NTLGmUwAICb7Jbe/CsWCktW363gh1MOcpEcSO3mJ344Gv2dqz8YJCLQpb6hju/0qOWw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.3.0.tgz",
+      "integrity": "sha512-ITWT1Wqjubf2CJthb0BuT9+bpzBfXeMokH/AAa5EJQgbv9aPMVfnM76iFIZVFf50hYXGbtiV71BHAthNWd6+dw==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.0.0.tgz",
-      "integrity": "sha512-/YNnLoHsR+4W4Vf2wL5lGv0ksg8Bmk3GEGxn2vEQt52AQaPSCuaO5PM5VM7lP1K9qHRKHwrPGktqVoAHKWHxzw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "dependencies": {
-        "@smithy/is-array-buffer": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.1.0.tgz",
-      "integrity": "sha512-S6V0JvvhQgFSGLcJeT1CBsaTR03MM8qTuxMH9WPCCddlSo2W0V5jIHimHtIQALMLEDPGQ0ROSRr/dU0O+mxiQg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.3.0.tgz",
+      "integrity": "sha512-HZkzrRcuFN1k70RLqlNK4FnPXKOpkik1+4JaBoHNJn+RnJGYqaa3c5/+XtLOXhlKzlRgNvyaLieHTW2VwGN0VQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.0.24.tgz",
-      "integrity": "sha512-TsP5mBuLgO2C21+laNG2nHYZEyUdkbGURv2tHvSuQQxLz952MegX95uwdxOY2jR2H4GoKuVRfdJq7w4eIjGYeg==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.2.1.tgz",
+      "integrity": "sha512-RtKW+8j8skk17SYowucwRUjeh4mCtnm5odCL0Lm2NtHQBsYKrNW0od9Rhopu9wF1gHMfHeWF7i90NwBz/U22Kw==",
       "dependencies": {
-        "@smithy/property-provider": "^2.0.17",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
         "bowser": "^2.11.0",
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "2.0.32",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.0.32.tgz",
-      "integrity": "sha512-d0S33dXA2cq1NyorVMroMrEtqKMr3MlyLITcfTBf9pXiigYiPMOtbSI7czHIfDbuVuM89Cg0urAgpt73QV9mPQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.3.1.tgz",
+      "integrity": "sha512-vkMXHQ0BcLFysBMWgSBLSk3+leMpFSyyFj8zQtv5ZyUBx8/owVh1/pPEkzmW/DR/Gy/5c8vjLDD9gZjXNKbrpA==",
       "dependencies": {
-        "@smithy/config-resolver": "^2.0.23",
-        "@smithy/credential-provider-imds": "^2.1.5",
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/property-provider": "^2.0.17",
-        "@smithy/smithy-client": "^2.2.1",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/config-resolver": "^2.2.0",
+        "@smithy/credential-provider-imds": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.0.8.tgz",
-      "integrity": "sha512-l8zVuyZZ61IzZBYp5NWvsAhbaAjYkt0xg9R4xUASkg5SEeTT2meHOJwJHctKMFUXe4QZbn9fR2MaBYjP2119+w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.2.0.tgz",
+      "integrity": "sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==",
       "dependencies": {
-        "@smithy/node-config-provider": "^2.1.9",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.0.0.tgz",
-      "integrity": "sha512-c5xY+NUnFqG6d7HFh1IFfrm3mGl29lC+vF+geHv4ToiuJCBmIfzx6IeHLg+OgRdPFKDXIw6pvi+p3CsscaMcMA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.0.9.tgz",
-      "integrity": "sha512-PnCnBJ07noMX1lMDTEefmxSlusWJUiLfrme++MfK5TD0xz8NYmakgoXy5zkF/16zKGmiwOeKAztWT/Vjk1KRIQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
       "dependencies": {
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.0.9.tgz",
-      "integrity": "sha512-46BFWe9RqB6g7f4mxm3W3HlqknqQQmWHKlhoqSFZuGNuiDU5KqmpebMbvC3tjTlUkqn4xa2Z7s3Hwb0HNs5scw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.2.0.tgz",
+      "integrity": "sha512-q9+pAFPTfftHXRytmZ7GzLFFrEGavqapFc06XxzZFcSIGERXMerXxCitjOG1prVDR9QdjqotF40SWvbqcCpf8g==",
       "dependencies": {
-        "@smithy/service-error-classification": "^2.0.9",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/service-error-classification": "^2.1.5",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "2.0.24",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.0.24.tgz",
-      "integrity": "sha512-hRpbcRrOxDriMVmbya+Mv77VZVupxRAsfxVDKS54XuiURhdiwCUXJP0X1iJhHinuUf6n8pBF0MkG9C8VooMnWw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^2.3.2",
-        "@smithy/node-http-handler": "^2.2.2",
-        "@smithy/types": "^2.8.0",
-        "@smithy/util-base64": "^2.0.1",
-        "@smithy/util-buffer-from": "^2.0.0",
-        "@smithy/util-hex-encoding": "^2.0.0",
-        "@smithy/util-utf8": "^2.0.2",
-        "tslib": "^2.5.0"
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.0.0.tgz",
-      "integrity": "sha512-ebkxsqinSdEooQduuk9CbKcI+wheijxEb3utGXkCoYQkJnwTnLbH1JXGimJtUkQwNQbsbuYwG2+aFVyZf5TLaw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
       "dependencies": {
-        "tslib": "^2.5.0"
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.0.2.tgz",
-      "integrity": "sha512-qOiVORSPm6Ce4/Yu6hbSgNHABLP2VMv8QOC3tTDNHHlWY19pPyc++fBTbZPtx6egPXi4HQxKDnMxVxpbtX2GoA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "dependencies": {
-        "@smithy/util-buffer-from": "^2.0.0",
-        "tslib": "^2.5.0"
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.0.16.tgz",
-      "integrity": "sha512-5i4YONHQ6HoUWDd+X0frpxTXxSXgJhUFl+z0iMy/zpUmVeCQY2or3Vss6DzHKKMMQL4pmVHpQm9WayHDorFdZg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.2.0.tgz",
+      "integrity": "sha512-IHk53BVw6MPMi2Gsn+hCng8rFA3ZmR3Rk7GllxDUW9qFJl/hiSvskn7XldkECapQVkIg/1dHpMAxI9xSTaLLSA==",
       "dependencies": {
-        "@smithy/abort-controller": "^2.0.16",
-        "@smithy/types": "^2.8.0",
-        "tslib": "^2.5.0"
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -3449,6 +6103,14 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/duplexify": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/@types/duplexify/-/duplexify-3.6.4.tgz",
+      "integrity": "sha512-2eahVPsd+dy3CL6FugAzJcxoraWhUghZGEQJns1kTKfCXWKJ5iG/VkaB05wRVrDKHfOFKqb0X0kXh91eE99RZg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3543,6 +6205,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw=="
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -3899,14 +6566,14 @@
       "integrity": "sha512-amQ5OSW3OpIkrxVKLjxVBPk/T49yuOtnqs1z5ZPfZr0+OpTovzmiHbyoAGDIsu5SNYHwOZFp/3LGOnRaALFa/g=="
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
       "dependencies": {
-        "debug": "4"
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -4047,6 +6714,22 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/asn1.js/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/async": {
       "version": "3.2.5",
@@ -4612,6 +7295,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/body-parser": {
       "version": "1.20.1",
@@ -5517,6 +8205,17 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -5565,6 +8264,14 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -6179,9 +8886,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -6600,28 +9307,27 @@
       }
     },
     "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.0.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -8137,6 +10843,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
     "node_modules/minimatch": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
@@ -8156,7 +10867,6 @@
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-      "peer": true,
       "dependencies": {
         "obliterator": "^1.6.1"
       }
@@ -8242,8 +10952,7 @@
     "node_modules/obliterator": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "peer": true
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -9254,6 +11963,11 @@
         "npm": ">=6"
       }
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
+    },
     "node_modules/streamx": {
       "version": "2.15.6",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
@@ -10098,9 +12812,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -36,9 +36,12 @@
     "typescript": "~4.6.3"
   },
   "dependencies": {
+    "@aws-crypto/client-node": "^4.0.0",
     "@aws-sdk/client-cloudformation": "^3.465.0",
-    "@aws-sdk/client-qbusiness": "^3.470.0",
+    "@aws-sdk/client-dynamodb": "^3.574.0",
+    "@aws-sdk/client-qbusiness": "^3.574.0",
     "@aws-sdk/client-s3": "^3.465.0",
+    "@aws-sdk/client-sso-oidc": "^3.574.0",
     "@aws-sdk/lib-dynamodb": "^3.465.0",
     "@azure/msal-node": "^2.6.0",
     "@types/aws-lambda": "^8.10.119",
@@ -46,7 +49,7 @@
     "archiver": "^6.0.1",
     "aws-cdk-lib": "^2.110.1",
     "aws-sdk": "^2.1452.0",
-    "botbuilder": "4.21.3",
+    "botbuilder": "^4.21.3",
     "constructs": "^10.0.0",
     "express": "^4.18.2",
     "html-to-text": "^9.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my_amazon_q_teams_bot",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "bin": {
     "my_enterprise_q_teams_bot": "bin/my_amazon_q_teams_bot.js"
   },

--- a/publish.sh
+++ b/publish.sh
@@ -35,6 +35,7 @@ fi
 VERSION=$(jq -r '.version' package.json)
 [[ "${PREFIX}" == */ ]] && PREFIX="${PREFIX%?}"
 PREFIX_AND_VERSION=${PREFIX}/${VERSION}
+echo $PREFIX_AND_VERSION
 
 # Append region to bucket basename
 BUCKET=${BUCKET_BASENAME}-${REGION}
@@ -55,12 +56,16 @@ echo "Create temp environment file"
 envfile=/tmp/environment.json
 cat > /tmp/environment.json << _EOF
 {
-  "StackName": "AQSG",
+  "StackName": "AQTG",
   "AmazonQAppId": "QAPPID",
-  "AmazonQUserId": "QUSERID",
   "AmazonQRegion": "QREGION",
   "AmazonQEndpoint": "QENDPOINT",
-  "ContextDaysToLive": "QCONTEXTTTL"
+  "ContextDaysToLive": "QCONTEXTTTL",
+  "OIDCIdPName": "QOIDCIDPNAME",
+  "OIDCClientId": "QOIDCCLIENTID",
+  "OIDCIssuerURL": "QOIDCISSUERURL",
+  "GatewayIdCAppARN": "QGATEWAYIDCAPPARN",
+  "MicrosoftAppId": "MICROSOFTAPPID"
 }
 _EOF
 
@@ -68,7 +73,7 @@ echo "Running npm install and build..."
 npm install && npm run build
 
 echo "Running cdk bootstrap..."
-cdk bootstrap -c environment=./environment.json
+cdk bootstrap -c environment=$envfile
 
 echo "Running cdk synthesize to create artifacts and template"
 cdk synthesize --staging  -c environment=$envfile > /dev/null
@@ -90,9 +95,9 @@ if $PUBLIC; then
   files=$(aws s3api list-objects --bucket ${BUCKET} --prefix ${PREFIX_AND_VERSION} --query "(Contents)[].[Key]" --output text)
   for file in $files
     do
-    aws s3api put-object-acl --acl public-read --bucket ${BUCKET} --key $file
+    aws s3api put-object-acl --acl public-read --bucket ${BUCKET} --key $file --region us-east-1
     done
-  aws s3api put-object-acl --acl public-read --bucket ${BUCKET} --key ${PREFIX}/${MAIN_TEMPLATE}
+  aws s3api put-object-acl --acl public-read --bucket ${BUCKET} --key ${PREFIX}/${MAIN_TEMPLATE} --region us-east-1
 fi
 
 echo "OUTPUTS"

--- a/src/functions/oidc-callback-handler.ts
+++ b/src/functions/oidc-callback-handler.ts
@@ -1,0 +1,119 @@
+import { getOrThrowIfEmpty } from '@src/utils';
+import { makeLogger } from '@src/logging';
+import { finishSession, SessionManagerEnv } from '@helpers/idc/session-helpers';
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Callback, Context } from 'aws-lambda';
+import { CloudFormation } from 'aws-sdk';
+
+const logger = makeLogger('oidc-callback-handler');
+
+const processOIDCCallbackEventEnv = (env: NodeJS.ProcessEnv) => ({
+  CFN_STACK_NAME: getOrThrowIfEmpty(env.CFN_STACK_NAME),
+  CALLBACK_API_ENDPOINT_EXPORTED_NAME: getOrThrowIfEmpty(env.CALLBACK_API_ENDPOINT_EXPORTED_NAME),
+  AMAZON_Q_REGION: getOrThrowIfEmpty(env.AMAZON_Q_REGION),
+  OIDC_STATE_TABLE_NAME: getOrThrowIfEmpty(env.OIDC_STATE_TABLE_NAME),
+  IAM_SESSION_TABLE_NAME: getOrThrowIfEmpty(env.IAM_SESSION_CREDENTIALS_TABLE_NAME),
+  OIDC_IDP_NAME: getOrThrowIfEmpty(env.OIDC_IDP_NAME),
+  OIDC_ISSUER_URL: getOrThrowIfEmpty(env.OIDC_ISSUER_URL),
+  OIDC_CLIENT_ID: getOrThrowIfEmpty(env.OIDC_CLIENT_ID),
+  OIDC_CLIENT_SECRET_NAME: getOrThrowIfEmpty(env.OIDC_CLIENT_SECRET_NAME),
+  KMS_KEY_ARN: getOrThrowIfEmpty(env.KEY_ARN),
+  Q_USER_API_ROLE_ARN: getOrThrowIfEmpty(env.Q_USER_API_ROLE_ARN),
+  GATEWAY_IDC_APP_ARN: getOrThrowIfEmpty(env.GATEWAY_IDC_APP_ARN)
+});
+
+export const handler = async (
+  event: APIGatewayProxyEvent,
+  _context: Context,
+  _callback: Callback,
+  dependencies = {
+    finishSession
+  },
+  oidcCallbackEventEnv: ReturnType<
+    typeof processOIDCCallbackEventEnv
+  > = processOIDCCallbackEventEnv(process.env)
+): Promise<APIGatewayProxyResult> => {
+  logger.debug(`Received GET request query parameters:  ${JSON.stringify(event)}`);
+  logger.debug(`env: ${JSON.stringify(oidcCallbackEventEnv)}`);
+
+  const oidcRedirectURL = await getExportedValue(
+    oidcCallbackEventEnv.CFN_STACK_NAME,
+    oidcCallbackEventEnv.CALLBACK_API_ENDPOINT_EXPORTED_NAME
+  );
+
+  const sessionManagerEnv: SessionManagerEnv = {
+    oidcStateTableName: oidcCallbackEventEnv.OIDC_STATE_TABLE_NAME,
+    iamSessionCredentialsTableName: oidcCallbackEventEnv.IAM_SESSION_TABLE_NAME,
+    oidcIdPName: oidcCallbackEventEnv.OIDC_IDP_NAME,
+    oidcClientId: oidcCallbackEventEnv.OIDC_CLIENT_ID,
+    oidcClientSecretName: oidcCallbackEventEnv.OIDC_CLIENT_SECRET_NAME,
+    oidcIssuerUrl: oidcCallbackEventEnv.OIDC_ISSUER_URL,
+    kmsKeyArn: oidcCallbackEventEnv.KMS_KEY_ARN,
+    region: oidcCallbackEventEnv.AMAZON_Q_REGION,
+    qUserAPIRoleArn: oidcCallbackEventEnv.Q_USER_API_ROLE_ARN,
+    gatewayIdCAppArn: oidcCallbackEventEnv.GATEWAY_IDC_APP_ARN,
+    oidcRedirectUrl: oidcRedirectURL
+  };
+
+  const queryStringParameters = event.queryStringParameters ?? {};
+  if (!queryStringParameters.code || !queryStringParameters.state) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: 'Invalid request'
+      })
+    };
+  }
+
+  try {
+    await dependencies.finishSession(
+      sessionManagerEnv,
+      queryStringParameters.code,
+      queryStringParameters.state
+    );
+
+    return {
+      headers: {
+        'Content-Type': 'text/plain'
+      },
+      statusCode: 200,
+      body: 'Authentication successful. You can close this window and return to Microsoft Teams.'
+    };
+  } catch (error) {
+    logger.error(`Error finishing session: ${error}`);
+    return {
+      headers: {
+        'Content-Type': 'text/plain'
+      },
+      statusCode: 500,
+      body: 'Internal server error'
+    };
+  }
+};
+
+const getExportedValue = async (stackName: string, exportedName: string): Promise<string> => {
+  const cloudFormation = new CloudFormation();
+  let nextToken: string | undefined;
+  let exportedValue: string | undefined;
+
+  do {
+    const listExportsResponse = await cloudFormation
+      .listExports({ NextToken: nextToken })
+      .promise();
+
+    const foundExport = listExportsResponse.Exports?.find(
+      (exp) => exp && exp.Name === exportedName
+    );
+
+    if (foundExport) {
+      exportedValue = foundExport.Value;
+      break;
+    }
+
+    nextToken = listExportsResponse.NextToken;
+  } while (nextToken);
+
+  return getOrThrowIfEmpty(
+    exportedValue,
+    `Exported value for ${exportedName} in stack ${stackName} is empty`
+  );
+};

--- a/src/helpers/dynamodb-client.ts
+++ b/src/helpers/dynamodb-client.ts
@@ -1,0 +1,16 @@
+import * as AWS from 'aws-sdk';
+
+export const client = new AWS.DynamoDB.DocumentClient({
+  region: process.env.AWS_REGION,
+  paramValidation: false, // Avoid extra latency
+  convertResponseTypes: false // Avoid extra latency
+});
+
+export const deleteItem = async (args: AWS.DynamoDB.DocumentClient.DeleteItemInput) =>
+  await client.delete(args).promise();
+
+export const putItem = async (args: AWS.DynamoDB.DocumentClient.PutItemInput) =>
+  await client.put(args).promise();
+
+export const getItem = async (args: AWS.DynamoDB.DocumentClient.GetItemInput) =>
+  await client.get(args).promise();

--- a/src/helpers/idc/encryption-helpers.ts
+++ b/src/helpers/idc/encryption-helpers.ts
@@ -1,0 +1,58 @@
+import { buildClient, CommitmentPolicy, KmsKeyringNode } from '@aws-crypto/client-node';
+
+type EncryptionContext = {
+  [key: string]: string;
+};
+
+const { encrypt, decrypt } = buildClient(CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT);
+
+// Encrypts the given data using the provided keyId and teamsUserId
+export const encryptData = async (data: string, keyId: string, teamsUserId: string) => {
+  if (!data || !keyId || !teamsUserId) {
+    throw new Error('Invalid arguments');
+  }
+  const keyring = new KmsKeyringNode({ generatorKeyId: keyId });
+  const contextData = buildContextData(teamsUserId);
+  const encryptionContext = buildEncryptionContext(contextData);
+
+  const { result } = await encrypt(keyring, data, { encryptionContext: encryptionContext });
+
+  return result.toString('base64');
+};
+
+// Decrypts the given cipherText using the provided keyId and teamsUserId
+export const decryptData = async (cipherText: string, keyId: string, teamsUserId: string) => {
+  // decode base64
+  const data = Buffer.from(cipherText, 'base64');
+  const keyring = new KmsKeyringNode({ generatorKeyId: keyId });
+
+  const { plaintext, messageHeader } = await decrypt(keyring, data);
+
+  // validate encryption context
+  const { encryptionContext } = messageHeader;
+  if (encryptionContext.teamsUserId !== teamsUserId) {
+    throw new Error('Invalid encryption context - teamsUserId mismatch');
+  }
+
+  return plaintext.toString();
+};
+
+// Builds an encryption context from the given contextData
+const buildEncryptionContext = (contextData: Record<string, string>): EncryptionContext => {
+  const encryptionContext: EncryptionContext = {};
+
+  for (const key in contextData) {
+    if (Object.prototype.hasOwnProperty.call(contextData, key)) {
+      encryptionContext[key] = contextData[key];
+    }
+  }
+
+  return encryptionContext;
+};
+
+// Builds context data for the given teamsUserId
+const buildContextData = (teamsUserId: string): Record<string, string> => {
+  return {
+    teamsUserId: teamsUserId
+  };
+};

--- a/src/helpers/idc/session-helpers.ts
+++ b/src/helpers/idc/session-helpers.ts
@@ -1,0 +1,373 @@
+import { Credentials, SecretsManager } from 'aws-sdk';
+import { makeLogger } from '@src/logging';
+import axios from 'axios';
+import { deleteItem, getItem, putItem } from '@helpers/dynamodb-client';
+import { CreateTokenWithIAMRequest, SSOOIDC } from '@aws-sdk/client-sso-oidc';
+import { AssumeRoleRequest, STS } from '@aws-sdk/client-sts';
+import jwt from 'jsonwebtoken';
+import * as crypto from 'crypto';
+import { decryptData, encryptData } from '@helpers/idc/encryption-helpers';
+
+const logger = makeLogger('teams-helpers');
+
+let secretManagerClient: SecretsManager | null = null;
+
+export type SessionManagerEnv = {
+  oidcStateTableName: string;
+  iamSessionCredentialsTableName: string;
+  oidcIdPName: string;
+  oidcIssuerUrl: string;
+  oidcClientId: string;
+  oidcClientSecretName: string;
+  oidcRedirectUrl: string;
+  kmsKeyArn: string;
+  region: string;
+  qUserAPIRoleArn: string;
+  gatewayIdCAppArn: string;
+};
+
+type Session = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken: string;
+  expiration: string;
+  refreshToken?: string;
+};
+
+export const getSessionCreds = async (env: SessionManagerEnv, teamsUserId: string) => {
+  logger.debug(`Getting session for teamsUserId ${teamsUserId}`);
+
+  let session = await loadSession(env, teamsUserId);
+
+  if (!hasSessionExpired(session.expiration)) {
+    return new Credentials(session.accessKeyId, session.secretAccessKey, session.sessionToken);
+  }
+
+  logger.debug('Session has expired');
+
+  if (session.refreshToken === undefined) {
+    logger.debug('No refresh token found');
+    throw new Error('SessionExpiredException');
+  }
+
+  logger.debug(`Refreshing session for teamsUserId ${teamsUserId}`);
+  const oidcSecrets = await getOIDCClientSecret(env.oidcClientSecretName, env.region);
+  const clientSecret = oidcSecrets.OIDCClientSecret;
+
+  // get token endpoint
+  const oidcEndpoints = await getOIDCEndpoints(env.oidcIssuerUrl);
+  const tokenEndpoint = oidcEndpoints.tokenEndpoint;
+  const refreshedTokens = await refreshToken(
+    session.refreshToken,
+    env.oidcClientId,
+    clientSecret,
+    tokenEndpoint
+  );
+
+  // exchange IdP id token for IAM session
+  session = await exchangeIdPTokenForIAMSessionCreds(
+    teamsUserId,
+    env,
+    refreshedTokens.id_token,
+    refreshedTokens.refresh_token
+  );
+
+  // save session
+  await saveSession(env, teamsUserId, session);
+
+  return new Credentials(session.accessKeyId, session.secretAccessKey, session.sessionToken);
+};
+
+export const startSession = async (env: SessionManagerEnv, teamsUserId: string) => {
+  const state = crypto.randomBytes(16).toString('hex');
+  const timestamp = new Date().toISOString();
+
+  logger.debug(`Starting session for teamsUserId ${teamsUserId} with state ${state}`);
+  // compute ttl now since epoch + 5 minutes
+  const ttl = Math.floor((Date.now() + 5 * 60 * 1000) / 1000);
+  await putItem({
+    TableName: env.oidcStateTableName,
+    Item: { state: state, teamsUserId: teamsUserId, timestamp: timestamp, ttl: ttl }
+  });
+
+  const oidcEndpoints = await getOIDCEndpoints(env.oidcIssuerUrl);
+
+  let scopes = 'openid email offline_access';
+  if (env.oidcIdPName.toLowerCase() === 'okta') {
+    // Okta allowed scopes: https://developer.okta.com/docs/api/oauth2/
+    scopes = 'openid email offline_access';
+  } else if (env.oidcIdPName.toLowerCase() === 'cognito') {
+    // Cognito allowed scopes: https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-define-resource-servers.html#cognito-user-pools-define-resource-servers-about-scopes
+    scopes = 'openid email';
+  }
+  const encodedScopes = encodeURIComponent(scopes);
+
+  return `${oidcEndpoints.authorizationEndpoint}?response_type=code&client_id=${
+    env.oidcClientId
+  }&redirect_uri=${encodeURIComponent(env.oidcRedirectUrl)}&state=${state}&scope=${encodedScopes}`;
+};
+
+export const finishSession = async (
+  env: SessionManagerEnv,
+  authorization_code: string,
+  state: string
+) => {
+  const getItemResponse = await getItem({
+    TableName: env.oidcStateTableName,
+    Key: {state: state}
+  });
+
+  if (!getItemResponse.Item) {
+    throw new Error('InvalidState');
+  }
+
+  // delete state from dynamodb and get the teams user id from the state
+  await deleteItem({
+    TableName: env.oidcStateTableName,
+    Key: {state: state}
+  });
+
+  // get teamsUserId from the attributes
+  const teamsUserId = getItemResponse.Item.teamsUserId;
+  logger.debug(`teams user id ${teamsUserId}`);
+
+  const oidcSecrets = await getOIDCClientSecret(env.oidcClientSecretName, env.region);
+  const clientSecret = oidcSecrets.OIDCClientSecret;
+
+  // get token endpoint
+  const oidcEndpoints = await getOIDCEndpoints(env.oidcIssuerUrl);
+  const tokenEndpoint = oidcEndpoints.tokenEndpoint;
+
+  // exchange code for token
+  const data = {
+    grant_type: 'authorization_code',
+    code: authorization_code,
+    redirect_uri: env.oidcRedirectUrl,
+    client_id: env.oidcClientId,
+    client_secret: clientSecret
+  };
+
+  const queryString = toQueryString(data);
+
+  const response = await axios.post(tokenEndpoint, queryString, {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    }
+  });
+
+  // call exchangeIdPTokenForIAMSessionCreds
+  const session = await exchangeIdPTokenForIAMSessionCreds(
+    teamsUserId,
+    env,
+    response.data.id_token,
+    response.data.refresh_token
+  );
+
+  // save session
+  await saveSession(env, teamsUserId, session);
+};
+
+const getSSOOIDCClient = (region: string) => {
+  return new SSOOIDC({ region: region });
+};
+
+type OIDCSecrets = {
+  OIDCClientSecret: string;
+};
+const getOIDCClientSecret = async (secretName: string, region: string): Promise<OIDCSecrets> => {
+  logger.debug(`Getting secret value for SecretId ${secretName}`);
+  const secret = await getSecretManagerClient(region)
+    .getSecretValue({
+      SecretId: secretName
+    })
+    .promise();
+
+  if (secret.SecretString === undefined) {
+    throw new Error(`Missing secret value for ${secretName}`);
+  }
+
+  return JSON.parse(secret.SecretString);
+};
+
+const getSecretManagerClient = (region: string) => {
+  if (secretManagerClient === null) {
+    secretManagerClient = new SecretsManager({ region: region });
+  }
+
+  return secretManagerClient;
+};
+
+type OIDCEndpoints = {
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+};
+
+async function getOIDCEndpoints(issuerUrl: string): Promise<OIDCEndpoints> {
+  const response = await axios.get(`${issuerUrl}/.well-known/openid-configuration`);
+
+  return {
+    authorizationEndpoint: response.data.authorization_endpoint,
+    tokenEndpoint: response.data.token_endpoint
+  };
+}
+
+function toQueryString(params: Record<string, string>) {
+  const parts = [];
+  for (const key in params) {
+    if (Object.prototype.hasOwnProperty.call(params, key)) {
+      const value = params[key];
+      parts.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+    }
+  }
+  return parts.join('&');
+}
+
+type RefreshTokensResponse = {
+  id_token: string;
+  refresh_token?: string;
+};
+
+const refreshToken = async (
+  refreshToken: string,
+  client_id: string,
+  client_secret: string,
+  token_endpoint: string
+) => {
+  const data = {
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: client_id,
+    client_secret: client_secret
+  };
+
+  const queryString = toQueryString(data);
+
+  const response = await axios.post(token_endpoint, queryString, {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    }
+  });
+
+  // parse the response
+  const refreshTokensResponse = response.data as RefreshTokensResponse;
+  if (refreshTokensResponse.refresh_token === undefined) {
+    refreshTokensResponse.refresh_token = refreshToken;
+  }
+
+  return refreshTokensResponse;
+};
+
+const exchangeIdPTokenForIAMSessionCreds = async (
+  teamsUserId: string,
+  env: SessionManagerEnv,
+  idToken: string,
+  refreshToken?: string
+) => {
+  // exchange IdP id token for IdC id token
+  const idCAppClientId = env.gatewayIdCAppArn;
+
+  const createTokenWithIAMRequest: CreateTokenWithIAMRequest = {
+    clientId: idCAppClientId,
+    grantType: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+    assertion: idToken
+  };
+
+  const idcResponse = await getSSOOIDCClient(env.region).createTokenWithIAM(
+    createTokenWithIAMRequest
+  );
+
+  const idcIdToken = idcResponse.idToken!;
+
+  // decode the jwt token
+  const decodedToken = jwt.decode(idcIdToken, { complete: true });
+
+  if (!decodedToken || typeof decodedToken !== 'object' || !decodedToken.payload) {
+    throw new Error('Invalid token');
+  }
+
+  // Define a type for the payload
+  interface Payload {
+    'sts:identity_context': string;
+  }
+
+  // Extract 'sts:identity-context' claim using type assertion
+  const identityContext = (decodedToken.payload as Payload)['sts:identity_context'];
+
+  // call sts assume role
+  const stsClient = new STS({ region: env.region });
+  const assumeRoleRequest: AssumeRoleRequest = {
+    RoleArn: env.qUserAPIRoleArn,
+    RoleSessionName: 'q-gateway-for-teams',
+    DurationSeconds: 3600,
+    ProvidedContexts: [
+      {
+        ProviderArn: 'arn:aws:iam::aws:contextProvider/IdentityCenter',
+        ContextAssertion: identityContext
+      }
+    ]
+  };
+
+  const assumeRoleResponse = await stsClient.assumeRole(assumeRoleRequest);
+
+  // extract access key, secret key and session token and expiry
+  const accessKeyId = assumeRoleResponse.Credentials?.AccessKeyId;
+  const secretAccessKey = assumeRoleResponse.Credentials?.SecretAccessKey;
+  const sessionToken = assumeRoleResponse.Credentials?.SessionToken;
+  const expiration = assumeRoleResponse.Credentials?.Expiration;
+
+  // put credentials in a record
+  const sessionCreds: Session = {
+    accessKeyId: accessKeyId!,
+    secretAccessKey: secretAccessKey!,
+    sessionToken: sessionToken!,
+    expiration: expiration!.toISOString(),
+    refreshToken: refreshToken
+  };
+
+  return sessionCreds;
+};
+
+const saveSession = async (env: SessionManagerEnv, teamsUserId: string, sessionCreds: Session) => {
+  const sessionCredsString = JSON.stringify(sessionCreds);
+
+  const encryptedCreds = await encryptData(sessionCredsString, env.kmsKeyArn, teamsUserId);
+
+  // store these in dynamodb table
+  const timestamp = new Date().toISOString();
+  await putItem({
+    TableName: env.iamSessionCredentialsTableName,
+    Item: {
+      teamsUserId: teamsUserId,
+      encryptedCreds: encryptedCreds,
+      expiration: sessionCreds.expiration,
+      timestamp: timestamp
+    }
+  });
+};
+
+const loadSession = async (env: SessionManagerEnv, teamsUserId: string) => {
+  const getItemResponse = await getItem({
+    TableName: env.iamSessionCredentialsTableName,
+    Key: { teamsUserId: teamsUserId }
+  });
+
+  if (!getItemResponse.Item) {
+    throw new Error('NoSessionExistsException');
+  }
+
+  const item = getItemResponse.Item;
+  const encryptedCreds: string = item.encryptedCreds;
+  const credsString = await decryptData(encryptedCreds, env.kmsKeyArn, teamsUserId);
+
+  return JSON.parse(credsString) as Session;
+};
+
+const hasSessionExpired = (expiration: string) => {
+  const expirationDate = new Date(expiration);
+  const now = new Date();
+
+  expirationDate.setMinutes(expirationDate.getMinutes() - 15);
+
+  return expirationDate <= now;
+
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,11 +45,21 @@ export const getOrThrowIfEmpty = <T>(value: T | undefined, name = 'element') => 
 export const getEnv = (env: NodeJS.ProcessEnv) => ({
   AMAZON_Q_ENDPOINT: env.AMAZON_Q_ENDPOINT,
   AMAZON_Q_APP_ID: getOrThrowIfEmpty(env.AMAZON_Q_APP_ID),
-  AMAZON_Q_USER_ID: env.AMAZON_Q_USER_ID,
   AMAZON_Q_REGION: getOrThrowIfEmpty(env.AMAZON_Q_REGION),
   CONTEXT_DAYS_TO_LIVE: getOrThrowIfEmpty(env.CONTEXT_DAYS_TO_LIVE),
   CACHE_TABLE_NAME: getOrThrowIfEmpty(env.CACHE_TABLE_NAME),
-  MESSAGE_METADATA_TABLE_NAME: getOrThrowIfEmpty(env.MESSAGE_METADATA_TABLE_NAME)
+  MESSAGE_METADATA_TABLE_NAME: getOrThrowIfEmpty(env.MESSAGE_METADATA_TABLE_NAME),
+  OIDC_STATE_TABLE_NAME: getOrThrowIfEmpty(env.OIDC_STATE_TABLE_NAME),
+  IAM_SESSION_TABLE_NAME: getOrThrowIfEmpty(env.IAM_SESSION_CREDENTIALS_TABLE_NAME),
+  OIDC_IDP_NAME: getOrThrowIfEmpty(env.OIDC_IDP_NAME),
+  OIDC_ISSUER_URL: getOrThrowIfEmpty(env.OIDC_ISSUER_URL),
+  OIDC_CLIENT_ID: getOrThrowIfEmpty(env.OIDC_CLIENT_ID),
+  OIDC_CLIENT_SECRET_NAME: getOrThrowIfEmpty(env.OIDC_CLIENT_SECRET_NAME),
+  OIDC_REDIRECT_URL: getOrThrowIfEmpty(env.OIDC_REDIRECT_URL),
+  KMS_KEY_ARN: getOrThrowIfEmpty(env.KEY_ARN),
+  Q_USER_API_ROLE_ARN: getOrThrowIfEmpty(env.Q_USER_API_ROLE_ARN),
+  GATEWAY_IDC_APP_ARN: getOrThrowIfEmpty(env.GATEWAY_IDC_APP_ARN),
+  MICROSOFT_APP_ID: getOrThrowIfEmpty(env.MICROSOFT_APP_ID),
 });
 
 export const getTeamsSecret = async () => {


### PR DESCRIPTION
*Issue #:* https://github.com/aws-samples/amazon-q-teams-gateway/issues/19

*Description of changes:*

These changes enable the Gateway to work with Q Business Apps integrated with Identity Center (IdC).

* The gateway registers the Amazon Q Business Microsoft Teams Gateway as an OpenID Connect (OIDC) app with Okta (or other OIDC compliant Identity Providers).
* This registration allows the gateway to invoke the Q Business ChatSync API on behalf of the end-user.
* The gateway provisions an OIDC callback handler for the Identity Provider (IdP) to return an authorization code after the end-user authenticates using the authorization grant flow.
* The callback handler exchanges the authorization code for IAM session credentials through a series of interactions with the IdP, IdC, and AWS Security Token Service (STS).
* The IAM session credentials, which are short-lived (15-minute duration), are encrypted and stored in a DynamoDB table along with the refresh token from the IdP.
* The IAM session credentials are then used to invoke the Q Business ChatSync and PutFeedback APIs.
* If the IAM session credentials expire, the refresh token from the IdP is used to obtain new IAM session credentials without requiring the end-user to sign in again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
