### PR TITLE
Remove ununsed scope - qbusiness:messages:access

### DIFF
--- a/bin/create-idc-application.sh
+++ b/bin/create-idc-application.sh
@@ -119,10 +119,6 @@ if ! aws sso-admin put-application-access-scope --application-arn $GATEWAY_IDC_A
     echo "Failed to set access scope for conversations."
     exit 1
 fi
-if ! aws sso-admin put-application-access-scope --application-arn $GATEWAY_IDC_ARN --scope "qbusiness:messages:access"; then
-    echo "Failed to set access scope for messages."
-    exit 1
-fi
 
 # Echo GATEWAY_IDC_ARN at the end
 echo "$APPLICATION_NAME is setup with GATEWAY_IDC_ARN: $GATEWAY_IDC_ARN"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change removes unused scope `qbusiness:messages:access` as it's getting deprecated. Only `qbusiness:messages:access` scope will be used for access qbusiness user APIs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
