### PR TITLE
Isolate Amazon Q Client for each Teams User

### DIFF
--- a/src/helpers/teams/q-teams-bot.ts
+++ b/src/helpers/teams/q-teams-bot.ts
@@ -505,7 +505,7 @@ export class QTeamsBot extends ActivityHandler {
       const messageResponse = await context.sendActivity(MessageFactory.text(PROCESSING_MSG));
 
       // call ChatSync API
-      const qResponse = await qChatSync(env, qUserMessage, qAttachments, iamSessionCreds, qContext);
+      const qResponse = await qChatSync(env,teamsUserId,qUserMessage, qAttachments, iamSessionCreds, qContext);
       if (qResponse instanceof Error) {
         const replyText = `${ERROR_MSG} : *${qResponse.message}*`;
         await context.sendActivity(MessageFactory.text(replyText));
@@ -633,6 +633,7 @@ export class QTeamsBot extends ActivityHandler {
       if (!isEmpty(qResponse.conversationId) && !isEmpty(qResponse.systemMessageId)) {
         await qPutFeedbackRequest(
           env,
+          teamsUserId,
           iamSessionCreds,
           {
             conversationId: qResponse.conversationId,


### PR DESCRIPTION
*Description of changes:  Update Amazon Q Client to use the teamsUserId to isolate the client and properly keep the user context


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
